### PR TITLE
Add regex format restriction for container_name

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -321,7 +321,7 @@ container_name: my-web-container
 Compose implementation MUST NOT scale a service beyond one container if the Compose file specifies a 
 `container_name`. Attempting to do so MUST result in an error.
 
-If represents, `container_name` SHOULD follow the regex fomrat of `[a-zA-Z0-9][a-zA-Z0-9_.-]+`
+If present, `container_name` SHOULD follow the regex format of `[a-zA-Z0-9][a-zA-Z0-9_.-]+`
 
 ### credential_spec
 

--- a/spec.md
+++ b/spec.md
@@ -321,6 +321,8 @@ container_name: my-web-container
 Compose implementation MUST NOT scale a service beyond one container if the Compose file specifies a 
 `container_name`. Attempting to do so MUST result in an error.
 
+If represents, `container_name` SHOULD follow the regex fomrat of `[a-zA-Z0-9][a-zA-Z0-9_.-]+`
+
 ### credential_spec
 
 `credential_spec` configures the credential spec for a managed service account.


### PR DESCRIPTION
Signed-off-by: Hang Yan <hangyan@alauda.io>

**What this PR does / why we need it**:
Add regex name restriction fort container_name feld.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #34

Seems this regex restrictions does not appear in the runtime spec, and it's reported by this issue 
https://github.com/moby/moby/issues/3138. Accounding the comments, this regex also apply for users and images, so i think it's fair enough to add this restirctions. As for kubernetes, it can easily use some transform methods to fit in this restriction.

