### PR TITLE
Readd support for `device_cgroup_rules`

### DIFF
--- a/schema/config_schema_v3.9.json
+++ b/schema/config_schema_v3.9.json
@@ -160,6 +160,7 @@
             }
           ]
         },
+        "device_cgroup_rules": {"$ref": "#/definitions/list_of_strings"},
         "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "dns": {"$ref": "#/definitions/string_or_list"},
         "dns_search": {"$ref": "#/definitions/string_or_list"},

--- a/spec.md
+++ b/spec.md
@@ -449,6 +449,18 @@ starting a dependent service.
 Compose implementations MUST guarantee dependency services marked with
 `service_healthy` are "healthy" before starting a dependent service.
 
+### device_cgroup_rules
+
+`device_cgroup_rules` defines a list of device cgroup rules for this container.
+The format is the same format the Linux kernel specifies in the [Control Groups
+Device Whitelist Controller](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/devices.html).
+
+```yml
+device_cgroup_rules:
+  - 'c 1:3 mr'
+  - 'a 7:* rmw'
+```
+
 ### devices
 
 `devices` defines a list of device mappings for created containers.


### PR DESCRIPTION
This readds support for `device_cgroup_rules` which was present in
compose file format 2.4.

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>

**What this PR does / why we need it**:
Readd the `device_cgroup_rules` property which was present in Compose 2.3. It will allow to use Compose files which enable devices selectively via cgroup rules.

**Which issue(s) this PR fixes**:
Fixes #62


