### PR TITLE
Add ipc: service mode to the spec

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1244,7 +1244,20 @@ expressed in the short form.
 
 ### ipc
 
-`ipc` configures the IPC isolation mode set by service container.
+`ipc` configures the IPC isolation mode set by service container. Available
+values are platform specific, but Compose specification defines specific values
+which MUST be implemented as described if supported:
+
+- `shareable` which gives the container own private IPC namespace, with a
+  possibility to share it with other containers.
+- `service:{name}` which makes the container join another (`shareable`)
+   container's IPC namespace.
+
+```yml
+    ipc: "shareable"
+    ipc: "service:[service name]"
+```
+
 
 ### mac_address
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aligns the `ipc` support for `service:[name]` syntax with existing functionality of `pid` and `network_mode`. The problem at hand is described in the linked issue (#70). The description of supported options was taken from [Docker docs](https://docs.docker.com/engine/reference/run/#ipc-settings---ipc).

In the words of @ndeloof in https://github.com/docker/compose/pull/7417:

> Sounds reasonable to me to align with other comparable attributes, but should first be discussed in https://github.com/compose-spec/compose-spec to ensure this get well set as supported compose syntax

**Which issue(s) this PR fixes**:
Fixes #70.


