### PR TITLE
docs: typo top-level element configs

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -108,7 +108,7 @@ volumes:
     driver_opts:
       size: "10GiB"
 
-config:
+configs:
   httpd-config:
     external: true
 


### PR DESCRIPTION
**What this PR does / why we need it:**
According to https://docs.docker.com/compose/compose-file/#configs-configuration-reference the top-level element `configs:` is used in plural.