### PR TITLE
Make `version` optional and define strict/standard/loose parsing mode

### DIFF
--- a/build.md
+++ b/build.md
@@ -56,7 +56,6 @@ attribute, whenever the actual raw yaml file doesn't explicitly declare one.
 The following sample illustrates Compose specification concepts with a concrete sample application. The sample is non-normative.
 
 ```yaml
-version: "3"
 services:
   frontend:
     image: awesome/webapp
@@ -87,7 +86,6 @@ The `build` element define configuration options that are applied by Compose imp
 `build` can be specified either as a string containing a path to the build context or a detailled structure:
 
 ```yml
-version: "3"
 services:
   webapp:
     build: ./dir

--- a/deploy.md
+++ b/deploy.md
@@ -19,7 +19,6 @@ Compose Specification is extended to support an OPTIONAL `deploy` subsection on 
 for a service.
 
 
-
 ### endpoint_mode
 
 `endpoint_mode` specifies a service discovery method for external clients connecting to a service. Default and available values
@@ -34,8 +33,6 @@ are platform specific, anyway the Compose specification define two canonical val
 
 
 ```yml
-version: "3"
-
 services:
   frontend:
     image: awesome/webapp
@@ -53,8 +50,7 @@ services:
 `labels` specifies metadata for the service. These labels MUST *only* be set on the service and *not* on any containers for the service.
 This assumes the platform as some native concept of "service" that can match Compose application model.
 
-```yaml
-version: "3"
+```yml
 services:
   frontend:
     image: awesome/webapp
@@ -69,8 +65,7 @@ services:
 `mode` define the replication model used to run the service on platform. Either `global` (exactly one container per physical node) or `replicated` (a specified number of containers). The default is `replicated`.
 
 
-```yaml
-version: "3"
+```yml
 services:
   frontend:
     image: awesome/webapp
@@ -129,7 +124,6 @@ If the service is `replicated` (which is the default), `replicas` specifies the 
 running at any given time.
 
 ```yml
-version: "3"
 services:
   fronted:
     image: awesome/webapp
@@ -146,7 +140,6 @@ as a:
 - `reservations`: The platform MUST guarantee container can allocate at least the configured amount
 
 ```yml
-version: "3"
 services:
   frontend:
     image: awesome/webapp


### PR DESCRIPTION
**What this PR does / why we need it**:
This removes requirement for `version` and define parsing mode to manage unsupported or unknown properties. See discussion on #13 and community meeting notes

**Which issue(s) this PR fixes**:
Fixes #13 

