### PR TITLE
Specify the behaviour of extends field

### DIFF
--- a/schema/config_schema_v3.9.json
+++ b/schema/config_schema_v3.9.json
@@ -227,7 +227,23 @@
           },
           "uniqueItems": true
         },
+        "extends": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
 
+              "properties": {
+                "service": {"type": "string"},
+                "file": {"type": "string"}
+              },
+              "required": ["service"],
+              "additionalProperties": false
+            }
+          ]
+        },
         "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
         "group_add": {

--- a/spec.md
+++ b/spec.md
@@ -747,7 +747,7 @@ expose:
 ### extends
 
 Extend another service, in the current file or another, optionally overriding configuration. You can use
-`extends` on any service together with other configuration keys. The `extends` value must be a mapping
+`extends` on any service together with other configuration keys. The `extends` value MUST be a mapping
 defined with a required `service` and an optional `file` key.
 
 ```yaml

--- a/spec.md
+++ b/spec.md
@@ -783,10 +783,9 @@ Compose implementations MUST return an error in all of these cases.
 - File path, which can be either:
   - Relative path. This path is considered as relative to the location of the main Compose
     file.
-  - Absolute path. `~/` in path is expanded to the home directory of current user. `~user/`
-    is expanded to the home directory of `user` user.
+  - Absolute path.
 
-Service denoted by `service` must be present in the identified referenced Compose file.
+Service denoted by `service` MUST be present in the identified referenced Compose file.
 Compose implementations MUST return an error if:
 
 - Service denoted by `service` was not found

--- a/spec.md
+++ b/spec.md
@@ -771,7 +771,7 @@ The following restrictions apply to the service being referenced:
 - Services with `depends_on` cannot be used as a base
 - Services cannot have circular references with `extends`
 
-Compose implementations MUST return an error if all of these cases.
+Compose implementations MUST return an error in all of these cases.
 
 #### Finding referenced service
 
@@ -793,7 +793,7 @@ Compose implementations MUST return an error if service denoted by `service` was
 Two service definitions (_main_ one in the current Compose file) and (_referenced_ one,
 specified by `extends`) MUST be merged in the following way:
 
-- Scalar fields: values in _main_ service definition take precedence over values in the
+- Scalar fields: keys in _main_ service definition take precedence over keys in the
   _referenced_ one
 - Sequences: items are combined together into an new sequence
 - Mappings: keys in mappings of _main_ service definition take precedence over keys in

--- a/spec.md
+++ b/spec.md
@@ -744,6 +744,61 @@ expose:
   - "8000"
 ```
 
+### extends
+
+Extend another service, in the current file or another, optionally overriding configuration. You can use
+`extends` on any service together with other configuration keys. The `extends` value must be a dictionary
+defined with a required `service` and an optional `file` key.
+
+```yaml
+extends:
+  file: common.yml
+  service: webapp
+```
+
+If supported Compose implementations MUST process `extends` in the following way.
+`service` defines the name of the service being referenced as a base, for example `web` or `database`.
+The `file` is the location of a Compose configuration file defining that service.
+
+#### Restrictions
+
+The following restrictions apply to the service being referenced:
+
+- Services with `links` cannot be used as a base
+- Services with `volumes_from` cannot be used as a base
+- Services with `net: container` cannot be used as a base
+- Services with `network_mode: service` cannot be used as a base
+- Services with `depends_on` cannot be used as a base
+- Services cannot have circular references with `extends`
+
+Compose implementations MUST return an error if all of these cases.
+
+#### Finding referenced service
+
+`file` value can be:
+
+- Not present.
+  This indicates that another service within the same Compose file is being referenced.
+- File path, which can be either:
+  - Relative path. This path is considered as relative to the location of the main Compose
+    file.
+  - Absolute path. `~/` in path is expanded to the home directory of current user. `~user/`
+    is expanded to the home directory of `user` user.
+
+Service denoted by `service` must be present in the identified referenced Compose file.
+Compose implementations MUST return an error if service denoted by `service` was not found.
+
+#### Merging service definitions
+
+Two service definitions (_main_ one in the current Compose file) and (_referenced_ one,
+specified by `extends`) MUST be merged in the following way:
+
+- Scalar fields: values in _main_ service definition take precedence over values in the
+  _referenced_ one
+- Sequences: items are combined together into an new sequence
+- Mappings: keys in mappings of _main_ service definition take precedence over keys in
+  mappings of _referenced_ service definition
+
 ### external_links
 
 `external_links` link service containers to services managed outside this Compose application.

--- a/spec.md
+++ b/spec.md
@@ -765,11 +765,10 @@ If supported Compose implementations MUST process `extends` in the following way
 
 The following restrictions apply to the service being referenced:
 
-- Services with `links` cannot be used as a base
-- Services with `volumes_from` cannot be used as a base
-- Services with `net: container` cannot be used as a base
-- Services with `network_mode: service` cannot be used as a base
-- Services with `depends_on` cannot be used as a base
+- Services that have dependencies on other services cannot be used as a base. Therefore, any key
+  that introduces a dependency on another service is incompatible with `extends`. The
+  non-exhaustive list of such keys is: `links`, `volumes_from`, `container` mode (in `ipc`, `pid`,
+  `network_mode` and `net`), `service` mode (in `ipc`, `pid` and `network_mode`), `depends_on`.
 - Services cannot have circular references with `extends`
 
 Compose implementations MUST return an error in all of these cases.

--- a/spec.md
+++ b/spec.md
@@ -797,12 +797,12 @@ Compose implementations MUST return an error if:
 Two service definitions (_main_ one in the current Compose file and _referenced_ one
 specified by `extends`) MUST be merged in the following way:
 
-- Scalars: keys in _main_ service definition take precedence over keys in the
-  _referenced_ one.
-- Sequences: items are combined together into an new sequence. Order of elements is
-  preserved with the _referenced_ items coming first and _main_ items after.
 - Mappings: keys in mappings of _main_ service definition override keys in mappings
   of _referenced_ service definition. Keys that aren't overridden are included as is.
+- Sequences: items are combined together into an new sequence. Order of elements is
+  preserved with the _referenced_ items coming first and _main_ items after.
+- Scalars: keys in _main_ service definition take precedence over keys in the
+  _referenced_ one.
 
 ##### Mappings
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR specifies the behaviour of `extends` field. This should complete the merger of `v2`/`v3` specs and enable us to release the first iteration of Compose spec.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #67.


