### PR TITLE
remove references to `version` and schema=3.9

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,7 +1,5 @@
 # The Compose Specification
 
-version: 3.9
-
 ## Table of Contents
 
 - [Status of this document](#status-of-this-document)
@@ -1283,7 +1281,6 @@ deployed. Implementation is Platform specific.
 
 Example:
 ```yaml
-version: "2.4"
 services:
   app:
     image: busybox
@@ -1305,7 +1302,6 @@ networks. If unspecified, the default value is 0.
 
 In the following example, the app service connects to app_net_1 first as it has the highest priority. It then connects to app_net_3, then app_net_2, which uses the default priority value of 0.
 ```yaml
-version: "2.4"
 services:
   app:
     image: busybox


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove remaining uses of legacy `version` field in sample
Remove reference to `3.9` as compose-spec schema version regarding docker-compose



