### PR TITLE
Initial specification for accelerators

### DIFF
--- a/deploy.md
+++ b/deploy.md
@@ -201,7 +201,7 @@ deploy:
 
 ##### count
 
-If `count` is set to `-1` or not specified, Compose implementations MUST reserve all devices that satisfy the requested capabilities. Otherwise, Compose implementations MUST reserve at least the number of devices specified. The value is specified as an integer.
+If `count` is set to `all` or not specified, Compose implementations MUST reserve all devices that satisfy the requested capabilities. Otherwise, Compose implementations MUST reserve at least the number of devices specified. The value is specified as an integer.
 
 ```yml
 deploy:

--- a/deploy.md
+++ b/deploy.md
@@ -161,6 +161,89 @@ services:
 
 `memory` configures a limit or reservation on the amount of memory a container can allocate, set as a string expressing a [byte value](spec.md#specifying-byte-values).
 
+#### devices
+
+`devices` configures reservations of the devices a container can use. It contains a list of reservations, each set as an object with the following parameters: `capabilities`, `driver`, `count`, `device_ids` and `options`.
+
+Devices are reserved using a list of capabilities, making `capabilities` the only required field. A device MUST satisfy all the requested capabilities for a successful reservation.
+
+##### capabilities
+
+`capabilities` are set as a list of strings, expressing both generic and driver specific capabilities.
+The following generic capabilities are recognized today:
+
+- `gpu`: Graphics accelerator
+- `tpu`: AI accelerator
+
+To avoid name clashes, driver specific capabilities MUST be prefixed with the driver name.
+For example, reserving an nVidia CUDA-enabled accelerator might look like this:
+
+```yml
+deploy:
+  resources:
+    reservations:
+      devices:
+        - capabilities: ["nvidia-compute"]
+```
+
+##### driver
+
+A different driver for the reserved device(s) can be requested using `driver` field. The value is specified as a string.
+
+```yml
+deploy:
+  resources:
+    reservations:
+      devices:
+        - capabilities: ["nvidia-compute"]
+          driver: nvidia
+```
+
+##### count
+
+If `count` is set to `-1` or not specified, Compose implementations MUST reserve all devices that satisfy the requested capabilities. Otherwise, Compose implementations MUST reserve at least the number of devices specified. The value is specified as an integer.
+
+```yml
+deploy:
+  resources:
+    reservations:
+      devices:
+        - capabilities: ["tpu"]
+          count: 2
+```
+
+`count` and `device_ids` fields are exclusive. Compose implementations MUST return an error if both are specified.
+
+##### device_ids
+
+If `device_ids` is set, Compose implementations MUST reserve devices with the specified IDs providing they satisfy the requested capabilities. The value is specified as a list of strings.
+
+
+```yml
+deploy:
+  resources:
+    reservations:
+      devices:
+        - capabilities: ["gpu"]
+          device_ids: ["GPU-f123d1c9-26bb-df9b-1c23-4a731f61d8c7"]
+```
+
+`count` and `device_ids` fields are exclusive. Compose implementations MUST return an error if both are specified.
+
+##### options
+
+Driver specific options can be set with `options` as key-value pairs.
+
+```yml
+deploy:
+  resources:
+    reservations:
+      devices:
+        - capabilities: ["gpu"]
+          driver: gpuvendor
+          options:
+            virtualization: false
+```
 
 ### restart_policy
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a section to the spec enabling Compose to make use of the graphics/AI accelerators. Most common use case is nVidia CUDA-enabled GPUs, but (as mentioned in the issue) there are some other devices like TPUs (for generic accelerated machine learning) and VPUs (for accelerated machine learning in computer vision). The spec closely mirrors `DeviceRequest` type with a single simplification of having `capabilities` as a flat list of strings (as also seen in https://github.com/docker/compose/issues/6691#issuecomment-670700674). 

This is pretty much essential for developers that make use of containers for machine learning and other AI tasks. Without accelerators, developers are stuck using CPU for these tasks - which is considerably slower.

**Potential mapping:**
- `docker-compose` can make use `DeviceRequest` to reserve the right devices
- For Kubernetes:
  - `nvidia` driver + `gpu` capability can get translated to `limits: nvidia.com/gpu: 1`
  - `amd` driver + `gpu` capability can get translated to `limits: amd.com/gpu: 1`
  - `gcloud` driver + `tpu` capability can get translated to `cloud-tpus.google.com/v2: 8`
- On ECS, `nvidia` driver + `gpu` capability can be translated to:
```json
        "resourceRequirements" : [
            {
               "type" : "GPU", 
               "value" : "2"
            }
        ],
```
- On ACI, `nvidia` driver + `gpu` capability can be translated to below. `sku` can either be derived from `count` or specified as an `x-` field
```
          gpu:
            count: 1
            sku: K80
```

**Shoutout to:**
- @Lucidiot for exposing `DeviceRequest` API in `docker-py`: https://github.com/docker/docker-py/pull/2471
- @bkakilli for putting together a sample implementation of `DeviceRequest` API in `docker-compose`: https://github.com/docker/compose/issues/6691#issuecomment-670700674
- @vk1z for submitting the issue and providing maintainers with valuable insights around accelerators and containers
- @justincormack, @chris-crone and @ndeloof for helping guide the discussions and making sure this issue doesn't slip through the cracks 

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #74.


