### PR TITLE
de-deprecate `runtime`

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -334,7 +334,6 @@
         "read_only": {"type": "boolean"},
         "restart": {"type": "string"},
         "runtime": {
-          "deprecated": true,
           "type": "string"
         },
         "scale": {

--- a/spec.md
+++ b/spec.md
@@ -1492,9 +1492,11 @@ If `pull_policy` and `build` both presents, Compose implementations SHOULD build
 ```
 
 ### runtime
-_DEPRECATED: this attribute is low-level platform implementation detail_ 
 
 `runtime` specifies which runtime to use for the service’s containers.
+
+The value of `runtime` is specific to implementation.
+For example, `runtime` can be the name of [an implementation of OCI Runtime Spec](https://github.com/opencontainers/runtime-spec/blob/master/implementations.md), such as "runc".
 
 ```yml
 web:


### PR DESCRIPTION

**What this PR does / why we need it**:

De-deprecate `runtime`.

This field was ported from v2 and marked as deprecated in #78, but still useful for Kata and gVisor users.


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #101


