### PR TITLE
Allow string values for the `cpus` property

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -163,7 +163,7 @@
         "cpu_period": {"type": ["number", "string"]},
         "cpu_rt_period": {"type": ["number", "string"]},
         "cpu_rt_runtime": {"type": ["number", "string"]},
-        "cpus": {"type": "number", "minimum": 0},
+        "cpus": {"type": ["number", "string"]},
         "cpuset": {"type": "string"},
         "credential_spec": {
           "type": "object",
@@ -513,7 +513,7 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "number", "minimum": 0},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"}
               },
               "additionalProperties": false,
@@ -522,7 +522,7 @@
             "reservations": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "number", "minimum": 0},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "generic_resources": {"$ref": "#/definitions/generic_resources"}
               },


### PR DESCRIPTION
Relates to https://github.com/docker/compose/issues/7766 and https://github.com/docker/compose/pull/7768


