### PR TITLE
fix missing config in compose example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -431,6 +431,8 @@ services:
 configs:
   my_config:
     external: true
+  my_other_config:
+    external: true
 ```
 
 You can grant a service access to multiple configs, and you can mix long and short syntax.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a compose example. The paragraph above is mentioning a config `my_other_config`, which is missing in the example.

> The `redis` service does not have access to the `my_other_config` config.


