### PR TITLE
Add mapping for `DeviceRequest` to compose schema

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -599,7 +599,7 @@
         "type": "object",
         "properties": {
             "capabilities": {"$ref": "#/definitions/list_of_strings"},
-            "count": {"type": "integer"},
+            "count": {"type": ["string", "integer"]},
             "device_ids": {"$ref": "#/definitions/list_of_strings"},
             "driver":{"type": "string"},
             "options":{"$ref": "#/definitions/list_or_dict"}

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -525,7 +525,8 @@
               "properties": {
                 "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
-                "generic_resources": {"$ref": "#/definitions/generic_resources"}
+                "generic_resources": {"$ref": "#/definitions/generic_resources"},
+                "devices": {"$ref": "#/definitions/devices"}
               },
               "additionalProperties": false,
               "patternProperties": {"^x-": {}}
@@ -586,6 +587,23 @@
             "patternProperties": {"^x-": {}}
           }
         },
+        "additionalProperties": false,
+        "patternProperties": {"^x-": {}}
+      }
+    },
+    
+    "devices": {
+      "id": "#/definitions/devices",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+            "capabilities": {"$ref": "#/definitions/list_of_strings"},
+            "count": {"type": "integer"},
+            "device_ids": {"$ref": "#/definitions/list_of_strings"},
+            "driver":{"type": "string"},
+            "options":{"$ref": "#/definitions/list_or_dict"}
+          },
         "additionalProperties": false,
         "patternProperties": {"^x-": {}}
       }


### PR DESCRIPTION

**What this PR does / why we need it**:
We need an updated schema with the mapping for `DeviceRequest` to start working on the GPU support in docker-compose.

**Which issue(s) this PR fixes**:
Relates to https://github.com/compose-spec/compose-spec/pull/100 



