### PR TITLE
Introduce `profiles` for services

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -328,6 +328,7 @@
           "uniqueItems": true
         },
         "privileged": {"type": "boolean"},
+        "profiles": {"$ref": "#/definitions/list_of_strings"},
         "pull_policy": {"type": "string", "enum": [
           "always", "never", "if_not_present"
         ]},

--- a/spec.md
+++ b/spec.md
@@ -167,6 +167,64 @@ merged are hosted in other folders.
 As some Compose file elements can both be expressed as single strings or complex objects, merges MUST apply to
 the expanded form.
 
+### Profiles
+
+Profiles allow to adjust the Compose application model for various usages and environments. A Compose
+implementation SHOULD allow the user to define a set of active profiles. The exact mechanism is implementation
+specific and MAY include command line flags, environment variables, etc.
+
+The Services top-level element supports a `profiles` attribute to define a list of named profiles. Services without
+a `profiles` attribute set MUST always be enabled. A service MUST be ignored by the Compose
+implementation when none of the listed `profiles` match the active ones, unless the service is
+explicitly targeted by a command. In that case its `profiles` MUST be added to the set of active profiles.
+All other top-level elements are not affected by `profiles` and are always active.
+
+References to other services (by `links`, `extends` or shared resource syntax `service:xxx`) MUST not
+automatically enable a component that would otherwise have been ignored by active profiles. Instead the
+Compose implementation MUST return an error.
+
+#### Illustrative example
+
+```yaml
+services:
+  foo:
+    image: foo
+  bar:
+    image: bar
+    profiles:
+      - test
+  baz:
+    image: baz
+    depends_on:
+      - bar
+    profiles:
+      - test
+  zot:
+    image: zot
+    depends_on:
+      - bar
+    profiles:
+      - debug
+```
+
+- Compose application model parsed with no profile enabled only contains the `foo` service.
+- If profile `test` is enabled, model contains the services `bar` and `baz` which are enabled by the
+  `test` profile and service `foo` which is always enabled.
+- If profile `debug` is enabled, model contains both `foo` and `zot` services, but not `bar` and `baz`
+  and as such the model is invalid regarding the `depends_on` constraint of `zot`.
+- If profiles `debug` and `test` are enabled, model contains all services: `foo`, `bar`, `baz` and `zot`.
+- If Compose implementation is executed with `bar` as explicit service to run, it and the `test` profile
+  will be active even if `test` profile is not enabled _by the user_.
+- If Compose implementation is executed with `baz` as explicit service to run, the service `baz` and the
+  profile `test` will be active and `bar` will be pulled in by the `depends_on` constraint.
+- If Compose implementation is executed with `zot` as explicit service to run, again the model will be
+  invalid regarding the `depends_on` constraint of `zot` since `zot` and `bar` have no common `profiles`
+  listed.
+- If Compose implementation is executed with `zot` as explicit service to run and profile `test` enabled,
+  profile `debug` is automatically enabled and service `bar` is pulled in as a dependency starting both
+  services `zot` and `bar`.
+
+
 ## Version top-level element
 
 Top-level `version` property is defined by the specification for backward compatibility but is only informative. 
@@ -1459,6 +1517,12 @@ ports:
 ### privileged
 
 `privileged` configures the service container to run with elevated privileges. Support and actual impacts are platform-specific.
+
+### profiles
+
+`profiles` defines a list of named profiles for the service to be enabled under. When not set, service is always enabled.
+
+If present, `profiles` SHOULD follow the regex format of `[a-zA-Z0-9][a-zA-Z0-9_.-]+`.
 
 ### pull_policy
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce `profiles` in compose schema and specification.
This is based on the PR #98 by @ndeloof and the discussion in #97. It diverges from #98 by:
- limit initial scope to services only
- adds a regex for valid profile names (see https://github.com/compose-spec/compose-spec/pull/98#issuecomment-685732572)
- clarify that the profiles of services explicitly targeted by commands must be automatically enabled (see https://github.com/compose-spec/compose-spec/issues/97#issuecomment-685712571 and https://github.com/compose-spec/compose-spec/issues/97#issuecomment-683398226)
- added another example to demonstrate the last point

Automatically enabling the profiles of explicitly targeted service is the minimal amount of "magic" required here to allow for a sane UX when targeting services with dependencies in non-default profiles. But at the same time it still forces the users to specify a valid compose model where all dependencies share a common profile.

**Which issue(s) this PR fixes**:
Fixes #97
see also #98
Fixes #87