### PR TITLE
Updated memory properties with format byte

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -515,7 +515,7 @@
               "type": "object",
               "properties": {
                 "cpus": {"type": ["number", "string"]},
-                "memory": {"type": "string"}
+                "memory": {"type": "string", "format" : "byte"}
               },
               "additionalProperties": false,
               "patternProperties": {"^x-": {}}
@@ -524,7 +524,7 @@
               "type": "object",
               "properties": {
                 "cpus": {"type": ["number", "string"]},
-                "memory": {"type": "string"},
+                "memory": {"type": "string", "format": "byte"},
                 "generic_resources": {"$ref": "#/definitions/generic_resources"},
                 "devices": {"$ref": "#/definitions/devices"}
               },


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the format `byte` to all `memory` properties. The spec for [memory](https://github.com/compose-spec/compose-spec/blob/68a799e866c2a8ff5d553c3797564282347d2659/deploy.md#memory) indicates the value uses the [byte](https://github.com/compose-spec/compose-spec/blob/68a799e866c2a8ff5d553c3797564282347d2659/spec.md#specifying--byte-values) format


