### PR TITLE
Add missing “build” pull_policy option

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -330,7 +330,7 @@
         "privileged": {"type": "boolean"},
         "profiles": {"$ref": "#/definitions/list_of_strings"},
         "pull_policy": {"type": "string", "enum": [
-          "always", "never", "if_not_present"
+          "always", "never", "if_not_present", "build"
         ]},
         "read_only": {"type": "boolean"},
         "restart": {"type": "string"},

--- a/spec.md
+++ b/spec.md
@@ -1531,6 +1531,7 @@ If present, `profiles` SHOULD follow the regex format of `[a-zA-Z0-9][a-zA-Z0-9_
 * `always`: Compose implementations SHOULD always pull the image from the registry.
 * `never`: Compose implementations SHOULD NOT pull the image from a registry and SHOULD rely on the platform cached image. If there is no cached image, a failure MUST be reported.
 * `if_not_present`: Compose implementations SHOULD pull the image only if it's not available in the platform cache.This SHOULD be the default option for Compose implementations without build support.
+* `build`: Compose implementations SHOULD build the image. Compose implementations SHOULD rebuild the image if already present.
 
 If `pull_policy` and `build` both presents, Compose implementations SHOULD build the image by default. Compose implementations MAY override this behavior in the toolchain.
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What this PR does / why we need it**:
"build" option was missing in https://github.com/compose-spec/compose-spec/pull/59/files#diff-53d1d45e2e85eb9cd869712bc594fa2b30e554973a28c9e363d0dc8f21890bc2R166


