### PR TITLE
Remove duplicate values check for build.cache_from

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -87,7 +87,7 @@
                 "dockerfile": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
                 "labels": {"$ref": "#/definitions/list_or_dict"},
-                "cache_from": {"$ref": "#/definitions/list_of_strings"},
+                "cache_from": {"type": "array", "items": {"type": "string"}},
                 "network": {"type": "string"},
                 "target": {"type": "string"},
                 "shm_size": {"type": ["integer", "string"]},


### PR DESCRIPTION
The `docker` command accepts duplicate values, so there is no benefit to
performing this check.

Fixes https://github.com/docker/compose/issues/7342

