### PR TITLE
remove redundant dash

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -2362,7 +2362,7 @@ services:
     logging: *default-logging
 ```
 
-### specifying- byte values
+### specifying byte values
 
 Value express a byte value as a string in `{amount}{byte unit}` format:
 The supported units are `b` (bytes), `k` or `kb` (kilo bytes), `m` or `mb` (mega bytes) and `g` or `gb` (giga bytes).


### PR DESCRIPTION
There is a redundant dash in the title of _specifying byte values_ section that is wrong and furthermore prevents links to this section from working. E.g [here](https://github.com/compose-spec/compose-spec/blob/master/spec.md#shm_size) and [here](https://github.com/compose-spec/compose-spec/blob/master/deploy.md#memory)


