### PR TITLE
Fix single char typo in spec.md

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -700,7 +700,7 @@ dns_search:
 
 `entrypoint` overrides the default entrypoint for the Docker image (i.e. `ENTRYPOINT` set by Dockerfile).
 Compose implementations MUST clear out any default command on the Docker image - both `ENTRYPOINT` and `CMD` instruction
-in the Dockerfile - when `entrypoint` is configured by a Compose file. If [`command](#command) is also set,
+in the Dockerfile - when `entrypoint` is configured by a Compose file. If [`command`](#command) is also set,
 it is used as parameter to `entrypoint` as a replacement for Docker image's `CMD`
 
 ```yml


### PR DESCRIPTION
Missing backtick messed up the Markdown formatting in "entrypoint"
