### PR TITLE
Version is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,5 @@ The specification and code is licensed under the Apache 2.0 license found in the
 
 | Metadata |                  |
 | -------- | ---------------: |
-| Version  | 3.9              |
 | Status   | Work in progress |
 | Created  | 2020-01-02       |

--- a/build.md
+++ b/build.md
@@ -1,5 +1,4 @@
 # The Compose Specification - Build support
-version: 3.9
 
 *Note:* Build is an OPTIONAL part of the Compose Specification
 

--- a/deploy.md
+++ b/deploy.md
@@ -1,5 +1,4 @@
 # The Compose Specification - Deployment support
-version: 3.9
 
 *Note:* Deployment is an OPTIONAL part of the Compose Specification
 

--- a/spec.md
+++ b/spec.md
@@ -148,7 +148,7 @@ will use a platform-specific lookup mechanism to retrieve runtime values.
 ## Compose file
 
 The Compose file is a [YAML](http://yaml.org/) file defining
-[version](#version) (OPTIONAL),
+[version](#version) (DEPRECATED),
 [services](#service-top-level-element) (REQUIRED),
 [networks](#network-top-level-element),
 [volumes](#volume-top-level-element),

--- a/spec.md
+++ b/spec.md
@@ -148,7 +148,7 @@ will use a platform-specific lookup mechanism to retrieve runtime values.
 ## Compose file
 
 The Compose file is a [YAML](http://yaml.org/) file defining
-[version](#version) (REQUIRED),
+[version](#version) (OPTIONAL),
 [services](#service-top-level-element) (REQUIRED),
 [networks](#network-top-level-element),
 [volumes](#volume-top-level-element),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes any unneeded/leftover mentions of version in the spec and ensures that `version:` attribute is defined as optional.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #124.
