### PR TITLE
build: fix typo

### DIFF
--- a/build.md
+++ b/build.md
@@ -193,7 +193,7 @@ are platform-specific.
 
 ### labels
 
-`labels` add metadata to the resulting image. `labrls` can be set either as an array or a map.
+`labels` add metadata to the resulting image. `labels` can be set either as an array or a map.
 
 reverse-DNS notation SHOULD be used to prevent labels from conflicting with those used by other software.
 


### PR DESCRIPTION
**What this PR does / why we need it**: fixes trivial typo in documentation

**Which issue(s) this PR fixes**: n/a - trivial typo. can open an issue if strictly required.


