### PR TITLE
Add a dependsOn condition to wait for successful completion

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -188,7 +188,7 @@
                   "properties": {
                     "condition": {
                       "type": "string",
-                      "enum": ["service_started", "service_healthy"]
+                      "enum": ["service_started", "service_healthy, "service_completed_successfully"]
                     }
                   },
                   "required": ["condition"]

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -188,7 +188,7 @@
                   "properties": {
                     "condition": {
                       "type": "string",
-                      "enum": ["service_started", "service_healthy, "service_completed_successfully"]
+                      "enum": ["service_started", "service_healthy", "service_completed_successfully"]
                     }
                   },
                   "required": ["condition"]

--- a/spec.md
+++ b/spec.md
@@ -598,8 +598,8 @@ expressed in the short form.
   - `service_healthy`: specifies that a dependency is expected to be "healthy"
     (as indicated by [healthcheck](#healthcheck)) before starting a dependent
     service.
-  - `service_finished_successfully`: specifies that a dependency is expected to run 
-    to successful completion (as indicated by an exit code of 0)
+  - `service_completed_successfully`: specifies that a dependency is expected to run 
+    to successful completion before starting a dependent service.
 
 Service dependencies cause the following behaviors:
 

--- a/spec.md
+++ b/spec.md
@@ -598,6 +598,8 @@ expressed in the short form.
   - `service_healthy`: specifies that a dependency is expected to be "healthy"
     (as indicated by [healthcheck](#healthcheck)) before starting a dependent
     service.
+  - `service_finished_successfully`: specifies that a dependency is expected to run 
+    to successful completion (as indicated by an exit code of 0)
 
 Service dependencies cause the following behaviors:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the spec to add a `dependsOn.condition` that waits for the successful completion of a dependent service. This is important to help support init container workflows.

**Which issue(s) this PR fixes**:

Fixes #11 
