### PR TITLE
typo: missing word in sentence

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -2097,7 +2097,7 @@ volumes:
 ### external
 
 If set to `true`, `external` specifies that this volume already exist on the platform and its lifecycle is managed outside
-of that of the application. Compose implementations MUST NOT attempt to create these volumes, and MUST return an error they
+of that of the application. Compose implementations MUST NOT attempt to create these volumes, and MUST return an error if they
 do not exist.
 
 In the example below, instead of attempting to create a volume called


### PR DESCRIPTION
**Typo in spec.md**

Missing word in subsection "external" of section "Volumes top-level element"


_just close this, if simple typo pr are not appreciated._

