### PR TITLE
Fix typo in spec.md

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1476,7 +1476,7 @@ Host IP, if not set, MUST bind to all network interfaces. Port can be either a s
 value or a range. Host and container MUST use equivalent ranges.
 
 Either specify both ports (`HOST:CONTAINER`), or just the container port. In the latter case, the
-Compose implementation SHOULD automatically allocate and unassigned host port.
+Compose implementation SHOULD automatically allocate any unassigned host port.
 
 `HOST:CONTAINER` SHOULD always be specified as a (quoted) string, to avoid conflicts
 with [yaml base-60 float](https://yaml.org/type/float.html).


### PR DESCRIPTION
Typo.
"allocate and unassigned host port" -> "allocate any unassigned host port"

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #


