### PR TITLE
Docs cleanup (typos, etc)

### DIFF
--- a/build.md
+++ b/build.md
@@ -2,53 +2,50 @@
 
 *Note:* Build is an OPTIONAL part of the Compose Specification
 
-
 ## Introduction
 
-Compose specification is a platform-neutral way to define multi-container applications. A Compose implementation 
-focussing on development use-case to run application on local machine will obviously also support (re)building 
-application from sources. The Compose Build specification allows to define the build process within a Compose file 
+Compose specification is a platform-neutral way to define multi-container applications. A Compose implementation
+focussing on development use-case to run application on local machine will obviously also support (re)building
+application from sources. The Compose Build specification allows to define the build process within a Compose file
 in a portable way.
 
 ## Definitions
 
-Compose Specification is extended to support an OPTIONAL `build` subsection on services. This section define the 
-build requirements for service container image. Only a subset of Compose file services MAY define such a Build 
-subsection, others being created based on `Image` attribute. When a Build subsection is present for a service, it 
-is *valid* for a Compose file to miss an `Image` attribute for corresponding service, as Compose implementation 
+Compose Specification is extended to support an OPTIONAL `build` subsection on services. This section define the
+build requirements for service container image. Only a subset of Compose file services MAY define such a Build
+subsection, others being created based on `Image` attribute. When a Build subsection is present for a service, it
+is *valid* for a Compose file to miss an `Image` attribute for corresponding service, as Compose implementation
 can build image from source.
 
-Build can be either specified as a single string defining a context path, or as a detailed build definition. 
+Build can be either specified as a single string defining a context path, or as a detailed build definition.
 
-In the former case, the whole path is used as a Docker context to execute a docker build, looking for a canonical 
-`Dockerfile` at context root. Context path can be absolute or relative, and if so relative path MUST be resolved 
-from Compose file parent folder. As an absolute path prevent the Compose file to be portable, Compose implementation 
+In the former case, the whole path is used as a Docker context to execute a docker build, looking for a canonical
+`Dockerfile` at context root. Context path can be absolute or relative, and if so relative path MUST be resolved
+from Compose file parent folder. As an absolute path prevent the Compose file to be portable, Compose implementation
 SHOULD warn user accordingly.
 
-In the later case, build arguments can be specified, including an alternate `Dockerfile` location. This one can be 
-absolute or relative path. If Dockerfile path is relative, it MUST be resolved from context path.  As an absolute 
-path prevent the Compose file to be portable, Compose implementation SHOULD warn user if an absolute alternate 
+In the later case, build arguments can be specified, including an alternate `Dockerfile` location. This one can be
+absolute or relative path. If Dockerfile path is relative, it MUST be resolved from context path.  As an absolute
+path prevent the Compose file to be portable, Compose implementation SHOULD warn user if an absolute alternate
 Dockerfile path is used.
-
 
 ## Consistency with Image
 
-When service definition do include both `Image` attribute and a `Build` section, Compose implementation can't 
-guarantee a pulled image is strictly equivalent to building the same image from sources. Without any explicit 
-user directives, Compose implementation with Build support MUST first try to pull Image, then build from source 
-if image was not found on registry. Compose implementation MAY offer options to customize this behaviour by user 
+When service definition do include both `Image` attribute and a `Build` section, Compose implementation can't
+guarantee a pulled image is strictly equivalent to building the same image from sources. Without any explicit
+user directives, Compose implementation with Build support MUST first try to pull Image, then build from source
+if image was not found on registry. Compose implementation MAY offer options to customize this behaviour by user
 request.
 
 ## Publishing built images
 
-Compose implementation with Build support SHOULD offer an option to push built images to a registry. Doing so, it 
-MUST NOT try to push service images without an `Image` attribute. Compose implementation SHOULD warn user about 
+Compose implementation with Build support SHOULD offer an option to push built images to a registry. Doing so, it
+MUST NOT try to push service images without an `Image` attribute. Compose implementation SHOULD warn user about
 missing `Image` attribute which prevent image being pushed.
 
-Compose implementation MAY offer a mechanism to compute an `Image` attribute for service when not explicitly 
-declared in yaml file. In such a case, the resulting Compose configuration is considered to have a valid `Image` 
+Compose implementation MAY offer a mechanism to compute an `Image` attribute for service when not explicitly
+declared in yaml file. In such a case, the resulting Compose configuration is considered to have a valid `Image`
 attribute, whenever the actual raw yaml file doesn't explicitly declare one.
-
 
 ## Illustrative sample
 
@@ -70,12 +67,11 @@ services:
     build: ~/custom
 ```
 
-When used to build service images from source, such a Compose file will create three docker images: 
+When used to build service images from source, such a Compose file will create three docker images:
 
 * `awesome/webapp` docker image is build using `webapp` sub-directory within Compose file parent folder as docker build context. Lack of a `Dockerfile` within this folder will throw an error.
 * `awesome/database` docker image is build using `backend` sub-directory within Compose file parent folder. `backend.Dockerfile` file is used to define build steps, this file is searched relative to context path, which means for this sample `..` will resolve to Compose file parent folder, so `backend.Dockerfile` is a sibling file.
 * a docker image is build using `custom` directory within user's HOME as docker context. Compose implementation warn user about non-portable path used to build image.
-
 
 On push, both `awesome/webapp` and `awesome/database` docker images are pushed to (default) registry. `custom` service image is skipped as no `Image` attribute is set and user is warned about this missing attribute.
 
@@ -90,9 +86,8 @@ services:
     build: ./dir
 ```
 
-Using this string syntax, only the build context can be configured as a relative path to the Compose file's parent folder. 
+Using this string syntax, only the build context can be configured as a relative path to the Compose file's parent folder.
 This path MUST be a directory and contain a `Dockerfile`.
-
 
 Alternatively `build` can be an object with fields defined as follow
 
@@ -100,8 +95,8 @@ Alternatively `build` can be an object with fields defined as follow
 
 `context` defines either a path to a directory containing a Dockerfile, or a url to a git repository.
 
-When the value supplied is a relative path, it MUST be interpreted as relative to the location of the Compose file. 
-Compose implementations MUST warn user about absolute path used to define build context as those prevent Compose file 
+When the value supplied is a relative path, it MUST be interpreted as relative to the location of the Compose file.
+Compose implementations MUST warn user about absolute path used to define build context as those prevent Compose file
 for being portable.
 
 ```yml
@@ -112,9 +107,8 @@ build:
 ### dockerfile
 
 `dockerfile` allows to set an alternate Dockerfile. A relative path MUST be resolved from the build context.
-Compose implementations MUST warn user about absolute path used to define Dockerfile as those prevent Compose file 
+Compose implementations MUST warn user about absolute path used to define Dockerfile as those prevent Compose file
 for being portable.
-
 
 ```yml
 build:
@@ -127,6 +121,7 @@ build:
 `args` define build arguments, i.e. Dockerfile `ARG` values.
 
 Using following Dockerfile:
+
 ```Dockerfile
 ARG GIT_COMMIT
 RUN echo "Based on commit: $GIT_COMMIT"
@@ -137,7 +132,7 @@ RUN echo "Based on commit: $GIT_COMMIT"
 ```yml
 build:
   context: .
-  args:    
+  args:
     GIT_COMMIT: cdc3b19
 ```
 
@@ -188,7 +183,7 @@ configuration, which means for Linux `/etc/hosts` will get extra lines:
 
 ### isolation
 
-`isolation` specifies a build’s container isolation technology. Like [isolation](spec.md#isolation) supported values 
+`isolation` specifies a build’s container isolation technology. Like [isolation](spec.md#isolation) supported values
 are platform-specific.
 
 ### labels
@@ -241,7 +236,6 @@ build:
   context: .
   target: prod
 ```
-
 
 ## Implementations
 

--- a/build.md
+++ b/build.md
@@ -18,7 +18,7 @@ subsection, others being created based on `Image` attribute. When a Build subsec
 is *valid* for a Compose file to miss an `Image` attribute for corresponding service, as Compose implementation 
 can build image from source.
 
-Build can be either specified as a single string defining a context path, or as a detailled build definition. 
+Build can be either specified as a single string defining a context path, or as a detailed build definition. 
 
 In the former case, the whole path is used as a Docker context to execute a docker build, looking for a canonical 
 `Dockerfile` at context root. Context path can be absolute or relative, and if so relative path MUST be resolved 
@@ -82,7 +82,7 @@ On push, both `awesome/webapp` and `awesome/database` docker images are pushed t
 ## Build definition
 
 The `build` element define configuration options that are applied by Compose implementations to build Docker image from source.
-`build` can be specified either as a string containing a path to the build context or a detailled structure:
+`build` can be specified either as a string containing a path to the build context or a detailed structure:
 
 ```yml
 services:
@@ -148,7 +148,7 @@ build:
     - GIT_COMMIT=cdc3b19
 ```
 
-Value can be omited when specifying a build argument, in which case its value at build time MUST be obtained by user interaction,
+Value can be omitted when specifying a build argument, in which case its value at build time MUST be obtained by user interaction,
 otherwise build arg won't be set when building the Docker image.
 
 ```yml
@@ -193,7 +193,7 @@ are platform-specific.
 
 ### labels
 
-`labels` add metadata to the resulting image. `labrls` can be set either as an array or a map.
+`labels` add metadata to the resulting image. `labels` can be set either as an array or a map.
 
 reverse-DNS notation SHOULD be used to prevent labels from conflicting with those used by other software.
 

--- a/deploy.md
+++ b/deploy.md
@@ -8,28 +8,25 @@ Compose specification is a platform-neutral way to define multi-container applic
 deployment of application model MAY require some additional metadata as the Compose application model is way too abstract
 to reflect actual infrastructure needs per service, or lifecycle constraints.
 
-Compose Specification Deployment allows users to declare additional metadata on services so Compose implementations get 
+Compose Specification Deployment allows users to declare additional metadata on services so Compose implementations get
 relevant data to allocate adequate resources on platform and configure them to match user's needs.
-
 
 ## Definitions
 
 Compose Specification is extended to support an OPTIONAL `deploy` subsection on services. This section define runtime requirements
 for a service.
 
-
 ### endpoint_mode
 
 `endpoint_mode` specifies a service discovery method for external clients connecting to a service. Default and available values
 are platform specific, anyway the Compose specification define two canonical values:
 
-* `endpoint_mode: vip`: Assigns the service a virtual IP (VIP) that acts as the front end for clients to reach the service 
-  on a network. Platform routes requests between the client and nodes running the service, without client knowledge of how 
+* `endpoint_mode: vip`: Assigns the service a virtual IP (VIP) that acts as the front end for clients to reach the service
+  on a network. Platform routes requests between the client and nodes running the service, without client knowledge of how
   many nodes are participating in the service or their IP addresses or ports.
 
-* `endpoint_mode: dnsrr`: Platform sets up DNS entries for the service such that a DNS query for the service name returns a 
+* `endpoint_mode: dnsrr`: Platform sets up DNS entries for the service such that a DNS query for the service name returns a
   list of IP addresses (DNS round-robin), and the client connects directly to one of these.
-
 
 ```yml
 services:
@@ -42,7 +39,6 @@ services:
       replicas: 2
       endpoint_mode: vip
 ```
-
 
 ### labels
 
@@ -58,11 +54,9 @@ services:
         com.example.description: "This label will appear on the web service"
 ```
 
-
 ### mode
 
 `mode` define the replication model used to run the service on platform. Either `global` (exactly one container per physical node) or `replicated` (a specified number of containers). The default is `replicated`.
-
 
 ```yml
 services:
@@ -80,7 +74,6 @@ services:
 
 `constraints` defines a REQUIRED property the platform's node MUST fulfill to run service container. Can be set either
 by a list or a map with string values.
-
 
 ```yml
 deploy:
@@ -101,7 +94,6 @@ deploy:
 `preferences` defines a property the platform's node SHOULD fulfill to run service container. Can be set either
 by a list or a map with string values.
 
-
 ```yml
 deploy:
     placement:
@@ -115,7 +107,6 @@ deploy:
     preferences:
         datacenter: us-east
 ```
-
 
 ### replicas
 
@@ -135,6 +126,7 @@ services:
 
 `resources` configures physical resource constraints for container to run on platform. Those constraints can be configured
 as a:
+
 - `limits`: The platform MUST prevent container to allocate more
 - `reservations`: The platform MUST guarantee container can allocate at least the configured amount
 
@@ -217,7 +209,6 @@ deploy:
 
 If `device_ids` is set, Compose implementations MUST reserve devices with the specified IDs providing they satisfy the requested capabilities. The value is specified as a list of strings.
 
-
 ```yml
 deploy:
   resources:
@@ -248,7 +239,7 @@ deploy:
 
 `restart_policy` configures if and how to restart containers when they exit. If `restart_policy` is not set, Compose implementations MUST consider `restart` field set by service configuration.
 
-- `condition`: One of `none`, `on-failure` or `any` (default: `any`). 
+- `condition`: One of `none`, `on-failure` or `any` (default: `any`).
 - `delay`: How long to wait between restart attempts, specified as a [duration](spec.md#specifying-durations) (default: 0).
 - `max_attempts`: How many times to attempt to restart a container before giving up (default: never give up). If the restart does not
   succeed within the configured `window`, this attempt doesn't count toward the configured `max_attempts` value.
@@ -274,7 +265,7 @@ deploy:
 - `failure_action`: What to do if a rollback fails. One of `continue` or `pause` (default `pause`)
 - `monitor`: Duration after each task update to monitor for failure `(ns|us|ms|s|m|h)` (default 0s).
 - `max_failure_ratio`: Failure rate to tolerate during a rollback (default 0).
-- `order`: Order of operations during rollbacks. One of `stop-first` (old task is stopped before starting new one), 
+- `order`: Order of operations during rollbacks. One of `stop-first` (old task is stopped before starting new one),
    or `start-first` (new task is started first, and the running tasks briefly overlap) (default `stop-first`).
 
 ### update_config
@@ -286,9 +277,8 @@ deploy:
 - `failure_action`: What to do if an update fails. One of `continue`, `rollback`, or `pause` (default: `pause`).
 - `monitor`: Duration after each task update to monitor for failure `(ns|us|ms|s|m|h)` (default 0s).
 - `max_failure_ratio`: Failure rate to tolerate during an update.
-- `order`: Order of operations during updates. One of `stop-first` (old task is stopped before starting new one), 
+- `order`: Order of operations during updates. One of `stop-first` (old task is stopped before starting new one),
    or `start-first` (new task is started first, and the running tasks briefly overlap) (default `stop-first`).
-
 
 ```yml
 deploy:

--- a/spec.md
+++ b/spec.md
@@ -15,7 +15,6 @@
 - [Extension](#extension)
 - [Interpolation](#interpolation)
 
-
 ## Status of this document
 
 This document specifies the Compose file format used to define multi-containers applications. Distribution of this document is unlimited.
@@ -25,14 +24,14 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 ### Requirements and optional attributes
 
 The Compose specification includes properties designed to target a local [OCI](https://opencontainers.org/) container runtime,
-exposing Linux kernel specific configuration options, but also some Windows container specific properties, as well as cloud platform features related to resource placement on a cluster, replicated application distribution and scalability. 
+exposing Linux kernel specific configuration options, but also some Windows container specific properties, as well as cloud platform features related to resource placement on a cluster, replicated application distribution and scalability.
 
 We acknowledge that no Compose implementation is expected to support **all** attributes, and that support for some properties
 is Platform dependent and can only be confirmed at runtime. The definition of a versioned schema to control the supported
 properties in a Compose file, established by the [docker-compose](https://github.com/docker/compose) tool where the Compose
-file format was designed, doesn't offer any guarantee to the end-user attributes will be actually implemented. 
+file format was designed, doesn't offer any guarantee to the end-user attributes will be actually implemented.
 
-The specification defines the expected configuration syntax and behaviour, but - until noted - supporting any of those is OPTIONAL. 
+The specification defines the expected configuration syntax and behaviour, but - until noted - supporting any of those is OPTIONAL.
 
 A Compose implementation to parse a Compose file using unsupported attributes SHOULD warn user. We recommend implementors
 to support those running modes:
@@ -89,8 +88,8 @@ Both services communicate with each other on an isolated back-tier network, whil
                   +--------------------+        \_________________/
 ```
 
-
 The example application is composed of the following parts:
+
 - 2 services, backed by Docker images: `webapp` and `database`
 - 1 secret (HTTPS certificate), injected into the frontend
 - 1 configuration (HTTP), injected into the frontend
@@ -155,8 +154,8 @@ The Compose file is a [YAML](http://yaml.org/) file defining
 [configs](#configs-top-level-element) and
 [secrets](#secrets-top-level-element).
 The default path for a Compose file is `compose.yaml` (preferred) or `compose.yml` in working directory.
-Compose implementations SHOULD also support `docker-compose.yaml` and `docker-compose.yml` for backward compatibility. 
-If both files exist, Compose implementations MUST prefer canonical `compose.yaml` one. 
+Compose implementations SHOULD also support `docker-compose.yaml` and `docker-compose.yml` for backward compatibility.
+If both files exist, Compose implementations MUST prefer canonical `compose.yaml` one.
 
 Multiple Compose files can be combined together to define the application model. The combination of YAML files
 MUST be implemented by appending/overriding YAML elements based on Compose file order set by the user. Simple
@@ -224,16 +223,15 @@ services:
   profile `debug` is automatically enabled and service `bar` is pulled in as a dependency starting both
   services `zot` and `bar`.
 
-
 ## Version top-level element
 
-Top-level `version` property is defined by the specification for backward compatibility but is only informative. 
+Top-level `version` property is defined by the specification for backward compatibility but is only informative.
 
-A Compose implementation SHOULD NOT use this version to select an exact schema to validate the Compose file, but 
-prefer the most recent schema at the time it has been designed. 
+A Compose implementation SHOULD NOT use this version to select an exact schema to validate the Compose file, but
+prefer the most recent schema at the time it has been designed.
 
-Compose implementations SHOULD validate they can fully parse the Compose file. If some fields are unknown, typically 
-because the Compose file was written with fields defined by a newer version of the specification, Compose implementations 
+Compose implementations SHOULD validate they can fully parse the Compose file. If some fields are unknown, typically
+because the Compose file was written with fields defined by a newer version of the specification, Compose implementations
 SHOULD warn the user. Compose implementations MAY offer options to ignore unknown fields (as defined by ["loose"](#Requirements-and-optional-attributes) mode).
 
 ## Services top-level element
@@ -254,7 +252,7 @@ the Build section SHOULD be ignored and the Compose file MUST still be considere
 
 Build support is an OPTIONAL aspect of the Compose specification, and is described in detail [here](build.md)
 
-Each Service defines runtime constraints and requirements to run its containers. The `deploy` section groups 
+Each Service defines runtime constraints and requirements to run its containers. The `deploy` section groups
 these constraints and allows the platform to adjust the deployment strategy to best match containers' needs with
 available resources.
 
@@ -268,7 +266,7 @@ not implemented the Deploy section SHOULD be ignored and the Compose file MUST s
 ### blkio_config
 
 `blkio_config` defines a set of configuration options to set block IO limits for this service.
-                         
+
 ```yml
 services:
   foo:
@@ -294,7 +292,7 @@ services:
 
 #### device_read_bps, device_write_bps
 
-Set a limit in bytes per second for read / write operations on a given device. 
+Set a limit in bytes per second for read / write operations on a given device.
 Each item in the list MUST have two keys:
 
 - `path`: defining the symbolic path to the affected device.
@@ -302,7 +300,7 @@ Each item in the list MUST have two keys:
 
 #### device_read_iops, device_write_iops
 
-Set a limit in operations per second for read / write operations on a given device. 
+Set a limit in operations per second for read / write operations on a given device.
 Each item in the list MUST have two keys:
 
 - `path`: defining the symbolic path to the affected device.
@@ -310,7 +308,7 @@ Each item in the list MUST have two keys:
 
 #### weight
 
-Modify the proportion of bandwidth allocated to this service relative to other services. 
+Modify the proportion of bandwidth allocated to this service relative to other services.
 Takes an integer value between 10 and 1000, with 500 being the default.
 
 #### weight_device
@@ -319,7 +317,6 @@ Fine-tune bandwidth allocation by device. Each item in the list must have two ke
 
 - `path`: defining the symbolic path to the affected device.
 - `weight`: an integer value between 10 and 1000.
-
 
 ### cpu_count
 
@@ -345,7 +342,7 @@ on Linux kernel.
 
 ### cpu_rt_runtime
 
-`cpu_rt_runtime` configures CPU allocation parameters for platform with support for realtime scheduler. Can be either 
+`cpu_rt_runtime` configures CPU allocation parameters for platform with support for realtime scheduler. Can be either
 an integer value using microseconds as unit or a [duration](#specifying-durations).
 
 ```yml
@@ -364,9 +361,10 @@ an integer value using microseconds as unit or a [duration](#specifying-duration
 ```
 
 ### cpus
+
 _DEPRECATED: use [deploy.reservations.cpus](deploy.md#cpus)_
 
-`cpus` define the number of (potentially virtual) CPUs to allocate to service containers. This is a fractional number. 
+`cpus` define the number of (potentially virtual) CPUs to allocate to service containers. This is a fractional number.
 `0.000` means no limit.
 
 ### cpuset
@@ -503,7 +501,7 @@ You can grant a service access to multiple configs, and you can mix long and sho
 container_name: my-web-container
 ```
 
-Compose implementation MUST NOT scale a service beyond one container if the Compose file specifies a 
+Compose implementation MUST NOT scale a service beyond one container if the Compose file specifies a
 `container_name`. Attempting to do so MUST result in an error.
 
 If present, `container_name` SHOULD follow the regex format of `[a-zA-Z0-9][a-zA-Z0-9_.-]+`
@@ -598,7 +596,7 @@ expressed in the short form.
   - `service_healthy`: specifies that a dependency is expected to be "healthy"
     (as indicated by [healthcheck](#healthcheck)) before starting a dependent
     service.
-  - `service_completed_successfully`: specifies that a dependency is expected to run 
+  - `service_completed_successfully`: specifies that a dependency is expected to run
     to successful completion before starting a dependent service.
 
 Service dependencies cause the following behaviors:
@@ -1034,10 +1032,10 @@ configuration, which means for Linux `/etc/hosts` will get extra lines:
 
 ### group_add
 
-`group_add` specifies additional groups (by name or number) which the user inside the container MUST be a member of. 
+`group_add` specifies additional groups (by name or number) which the user inside the container MUST be a member of.
 
-An example of where this is useful is when multiple containers (running as different users) need to all read or write 
-the same file on a shared volume. That file can be owned by a group shared by all the containers, and specified in 
+An example of where this is useful is when multiple containers (running as different users) need to all read or write
+the same file on a shared volume. That file can be owned by a group shared by all the containers, and specified in
 `group_add`.
 
 ```yml
@@ -1048,7 +1046,7 @@ services:
       - mail
 ```
 
-Running `id` inside the created container MUST show that the user belongs to the `mail` group, which would not have 
+Running `id` inside the created container MUST show that the user belongs to the `mail` group, which would not have
 been the case if `group_add` were not declared.
 
 ### healthcheck
@@ -1103,10 +1101,9 @@ healthcheck:
 
 ### image
 
-`image` specifies the image to start the container from. Image MUST follow the Open Container Specification 
+`image` specifies the image to start the container from. Image MUST follow the Open Container Specification
 [addressable image format](https://github.com/opencontainers/org/blob/master/docs/docs/introduction/digests.md),
 as `[<registry>/][<project>/]<image>[:<tag>|@<digest>]`.
-
 
 ```yml
     image: redis
@@ -1115,9 +1112,9 @@ as `[<registry>/][<project>/]<image>[:<tag>|@<digest>]`.
     image: library/redis
     image: docker.io/library/redis
     image: my_private.registry:5000/redis
-```    
+```
 
-If the image does not exist on the platform, Compose implementations MUST attempt to pull it based on the `pull_policy`. 
+If the image does not exist on the platform, Compose implementations MUST attempt to pull it based on the `pull_policy`.
 Compose implementations with build support MAY offer alternative options for the end user to control precedence of
 pull over building the image from source, however pulling the image MUST be the default behavior.
 
@@ -1344,6 +1341,7 @@ known subnet and are purely managed by the operator, usually dependent on the ar
 deployed. Implementation is Platform specific.
 
 Example:
+
 ```yaml
 services:
   app:
@@ -1357,7 +1355,7 @@ services:
 networks:
   app_net:
     driver: bridge
-```    
+```
 
 #### priority
 
@@ -1365,6 +1363,7 @@ networks:
 networks. If unspecified, the default value is 0.
 
 In the following example, the app service connects to app_net_1 first as it has the highest priority. It then connects to app_net_3, then app_net_2, which uses the default priority value of 0.
+
 ```yaml
 services:
   app:
@@ -1388,15 +1387,17 @@ networks:
 `mac_address` sets a MAC address for service container.
 
 ### mem_limit
+
 _DEPRECATED: use [deploy.limits.memory](deploy.md#memory)_
 
 ### mem_reservation
+
 _DEPRECATED: use [deploy.reservations.memory](deploy.md#memory)_
 
 ### mem_swappiness
 
 `mem_swappiness` defines as a percentage (a value between 0 and 100) for the host kernel to swap out
-anonymous memory pages used by a container. 
+anonymous memory pages used by a container.
 
 - a value of 0 turns off anonymous page swapping.
 - a value of 100 sets all anonymous pages as swappable.
@@ -1405,9 +1406,9 @@ Default value is platform specific.
 
 ### memswap_limit
 
-`memswap_limit` defines the amount of memory container is allowed to swap to disk. This is a modifier 
+`memswap_limit` defines the amount of memory container is allowed to swap to disk. This is a modifier
 attribute that only has meaning if `memory` is also set. Using swap allows the container to write excess
-memory requirements to disk when the container has exhausted all the memory that is available to it. 
+memory requirements to disk when the container has exhausted all the memory that is available to it.
 There is a performance penalty for applications that swap memory to disk often.
 
 - If `memswap_limit` is set to a positive integer, then both `memory` and `memswap_limit` MUST be set. `memswap_limit` represents the total amount of memory and swap that can be used, and `memory` controls the amount used by non-swap memory. So if `memory`="300m" and `memswap_limit`="1g", the container can use 300m of memory and 700m (1g - 300m) swap.
@@ -1416,23 +1417,20 @@ There is a performance penalty for applications that swap memory to disk often.
 - If `memswap_limit` is unset, and `memory` is set, the container can use as much swap as the `memory` setting, if the host container has swap memory configured. For instance, if `memory`="300m" and `memswap_limit` is not set, the container can use 600m in total of memory and swap.
 - If `memswap_limit` is explicitly set to -1, the container is allowed to use unlimited swap, up to the amount available on the host system.
 
-
 ### oom_kill_disable
- 
-If `oom_kill_disable` is set Compose implementation MUST configure the platform so it won't kill the container in case 
+
+If `oom_kill_disable` is set Compose implementation MUST configure the platform so it won't kill the container in case
 of memory starvation.
- 
+
 ### oom_score_adj
 
-`oom_score_adj` tunes the preference for containers to be killed by platform in case of memory starvation. Value MUST 
+`oom_score_adj` tunes the preference for containers to be killed by platform in case of memory starvation. Value MUST
 be within [-1000,1000] range.
-
 
 ### pid
 
 `pid` sets the PID mode for container created by the Compose implementation.
 Supported values are platform specific.
-
 
 ### pid_limit
 
@@ -1445,7 +1443,7 @@ pids_limit: 10
 ### platform
 
 `platform` defines the target platform containers for this service will run on, using the `os[/arch[/variant]]` syntax.
-Compose implementation MUST use this attribute when declared to determine which version of the image will be pulled 
+Compose implementation MUST use this attribute when declared to determine which version of the image will be pulled
 and/or on which platform the service’s build will be performed.
 
 ```yml
@@ -1453,7 +1451,6 @@ platform: osx
 platform: windows/amd64
 platform: linux/arm64/v8
 ```
-
 
 ### ports
 
@@ -1531,11 +1528,11 @@ If present, `profiles` SHOULD follow the regex format of `[a-zA-Z0-9][a-zA-Z0-9_
 `pull_policy` defines the decisions Compose implementations will make when it starts to pull images. Possible values are:
 
 * `always`: Compose implementations SHOULD always pull the image from the registry.
-* `never`: Compose implementations SHOULD NOT pull the image from a registry and SHOULD rely on the platform cached image. 
-   If there is no cached image, a failure MUST be reported.   
-* `missing`: Compose implementations SHOULD pull the image only if it's not available in the platform cache. 
+* `never`: Compose implementations SHOULD NOT pull the image from a registry and SHOULD rely on the platform cached image.
+   If there is no cached image, a failure MUST be reported.
+* `missing`: Compose implementations SHOULD pull the image only if it's not available in the platform cache.
    This SHOULD be the default option for Compose implementations without build support.
-  `if_not_present` SHOULD be considered an alias for this value for backward compatibility   
+  `if_not_present` SHOULD be considered an alias for this value for backward compatibility
 * `build`: Compose implementations SHOULD build the image. Compose implementations SHOULD rebuild the image if already present.
 
 If `pull_policy` and `build` both presents, Compose implementations SHOULD build the image by default. Compose implementations MAY override this behavior in the toolchain.
@@ -1576,6 +1573,7 @@ web:
 ```
 
 ### scale
+
 -DEPRECATED: use [deploy/replicas](deploy.md#replicas)_
 
 `scale` specifies the default number of containers to deploy for this service.
@@ -1823,10 +1821,10 @@ expressed in the short form.
 
 ### volumes_from
 
-`volumes_from` mounts all of the volumes from another service or container, optionally specifying 
+`volumes_from` mounts all of the volumes from another service or container, optionally specifying
 read-only access (ro) or read-write (rw). If no access level is specified, then read-write MUST be used.
 
-String value defines another service in the Compose application model to mount volumes from. The 
+String value defines another service in the Compose application model to mount volumes from. The
 `container:` prefix, if supported, allows to mount volumes from a container that is not managed by the
 Compose implementation.
 
@@ -2310,7 +2308,7 @@ volumes:
 
 ## Extension
 
-Special extension fields can be of any format as long as their name starts with the `x-` character sequence. They can be used 
+Special extension fields can be of any format as long as their name starts with the `x-` character sequence. They can be used
 within any structure in a Compose file. This is the sole exception for Compose implementations to silently ignore unrecognized field.
 
 ```yml

--- a/spec.md
+++ b/spec.md
@@ -743,7 +743,7 @@ Relative path MUST be resolved from the Compose file's parent folder. As absolut
 file from being portable, Compose implementations SHOULD warn users when such a path is used to set `env_file`.
 
 Environment variables declared in the [environment](#environment) section
-MUST override these values &ndash; this holds true even if those values are
+MUST override these values – this holds true even if those values are
 empty or undefined.
 
 #### Env_file format
@@ -1184,7 +1184,7 @@ Compose implementations MUST create containers with canonical labels:
 - `com.docker.compose.project` set on all resources created by Compose implementation to the user project name
 - `com.docker.compose.service` set on service containers with service name as defined in the Compose file
 
-The `com.docker.compose` label prefix is reserved. Specifying labels with this previx in the Compose file MUST
+The `com.docker.compose` label prefix is reserved. Specifying labels with this prefix in the Compose file MUST
 result in a runtime error.
 
 ### links
@@ -1424,7 +1424,7 @@ of memory starvation.
  
 ### oom_score_adj
 
-`oom_score_adj` tunes the preference for containers to be killed by platform in case of memory starvation. Valu MUST 
+`oom_score_adj` tunes the preference for containers to be killed by platform in case of memory starvation. Value MUST 
 be within [-1000,1000] range.
 
 
@@ -1476,7 +1476,7 @@ Host IP, if not set, MUST bind to all network interfaces. Port can be either a s
 value or a range. Host and container MUST use equivalent ranges.
 
 Either specify both ports (`HOST:CONTAINER`), or just the container port. In the latter case, the
-Compose implementation SHOULD automatically allocate and unassigned host port.
+Compose implementation SHOULD automatically allocate any unassigned host port.
 
 `HOST:CONTAINER` SHOULD always be specified as a (quoted) string, to avoid conflicts
 with [yaml base-60 float](https://yaml.org/type/float.html).
@@ -2139,7 +2139,7 @@ labels:
   - "com.example.label-with-empty-value"
 ```
 
-Compose implementation MUST set `com.docker.compose.project` and `com.docker.compose.volmume` labels.
+Compose implementation MUST set `com.docker.compose.project` and `com.docker.compose.volume` labels.
 
 ### name
 
@@ -2176,9 +2176,9 @@ volumes:
 
 Configs allow services to adapt their behaviour without the need to rebuild a Docker image. Configs are comparable to Volumes from a service point of view as they are mounted into service's containers filesystem. The actual implementation detail to get configuration provided by the platform can be set from the Configuration definition.
 
-When granted accessto a config, the config content is mounted as a file in the container. The location of the mount point within the container defaults to `/<config-name>` in Linux containers and `C:\<config-name>` in Windows containers.
+When granted access to a config, the config content is mounted as a file in the container. The location of the mount point within the container defaults to `/<config-name>` in Linux containers and `C:\<config-name>` in Windows containers.
 
-By default, the config MUST be owned by the user running the container command but can be overriden by service configuration.
+By default, the config MUST be owned by the user running the container command but can be overridden by service configuration.
 By default, the config MUST have world-readable permissions (mode 0444), unless service is configured to override this.
 
 Services can only access configs when explicitly granted by a [`configs`](#configs) subsection.
@@ -2194,8 +2194,8 @@ application. The source of the config is either `file` or `external`.
   reference configs that contain special characters. The name is used as is
   and will **not** be scoped with the project name.
 
-In this example, `http_config` is created (as `<project_name>_http_config)`when the application is deployed,
-and `my_second_config` MUST already exists on Platform and value will be obtained by lookup.
+In this example, `http_config` is created (as `<project_name>_http_config`) when the application is deployed,
+and `my_second_config` MUST already exist on Platform and value will be obtained by lookup.
 
 In this example, `server-http_config` is created as `<project_name>_http_config` when the application is deployed,
 by registering content of the `httpd.conf` as configuration data.
@@ -2230,7 +2230,7 @@ Compose file need to explicitly grant access to the configs to relevant services
 
 ## Secrets top-level element
 
-Secrets are a flavour of Configs focussing on sensitive data, with specific constraint for this usage. As the platform implementation may significally differ from Configs, dedicated Secrets section allows to configure the related resources.
+Secrets are a flavour of Configs focussing on sensitive data, with specific constraint for this usage. As the platform implementation may significantly differ from Configs, dedicated Secrets section allows to configure the related resources.
 
 The top-level `secrets` declaration defines or references sensitive data that can be granted to the services in this
 application. The source of the secret is either `file` or `external`.
@@ -2384,9 +2384,9 @@ The supported units are `b` (bytes), `k` or `kb` (kilo bytes), `m` or `mb` (mega
 
 ### specifying durations
 
-Value express a duration as a string in thte in the form of `{value}{unit}`.
+Value express a duration as a string in the in the form of `{value}{unit}`.
 The supported units are `us` (microseconds), `ms` (milliseconds), `s` (seconds), `m` (minutes) and `h` (hours).
-Value can can combine mutiple values and using without separator.
+Value can can combine multiple values and using without separator.
 
 ```
   10ms


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fixes some spelling and grammar typos (I left valid alternate spellings alone)
- Also trims trailing whitespace, and adds/removes extra new lines where appropriate as flagged by [markdownlint](https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md) (I left mid-sentence line-breaks alone)

**Which issue(s) this PR fixes**:
N/A


