### PR TITLE
Add support for arbitrary CLI build commands to be passed through to the CLI builder.

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -92,7 +92,8 @@
                 "target": {"type": "string"},
                 "shm_size": {"type": ["integer", "string"]},
                 "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
-                "isolation": {"type": "string"}
+                "isolation": {"type": "string"},
+                "extra_cli_build_args": {"$ref": "list_of_strings"}
               },
               "additionalProperties": false,
               "patternProperties": {"^x-": {}}


### PR DESCRIPTION
**What this PR does / why we need it**: Add support for arbitrary CLI build commands to be passed through to the CLI builder.

**Which issue(s) this PR fixes**: https://github.com/docker/compose/pull/7997
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes https://github.com/docker/compose/pull/7997


