### PR TITLE
Add missing `service.storage_opts`

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -366,6 +366,7 @@
         "stdin_open": {"type": "boolean"},
         "stop_grace_period": {"type": "string", "format": "duration"},
         "stop_signal": {"type": "string"},
+        "storage_opt": {"type": "object"},
         "tmpfs": {"$ref": "#/definitions/string_or_list"},
         "tty": {"type": "boolean"},
         "ulimits": {

--- a/spec.md
+++ b/spec.md
@@ -1689,6 +1689,15 @@ If unset containers are stopped by the Compose Implementation by sending `SIGTER
 stop_signal: SIGUSR1
 ```
 
+### storage_opts
+
+`storage_opts` defines storage driver options for a service.
+
+```yml
+storage_opt:
+  size: '1G'
+```
+
 ### sysctls
 
 `sysctls` defines kernel parameters to set in the container. `sysctls` can use either an array or a map.


### PR DESCRIPTION
Missing `storage_opts` service property after we merged the versioned schemas.

https://docs.docker.com/compose/compose-file/compose-file-v2/#storage_opt

Relates to https://github.com/docker/compose/issues/8210


