### PR TITLE
introduce create_host_path

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -408,7 +408,8 @@
                   "bind": {
                     "type": "object",
                     "properties": {
-                      "propagation": {"type": "string"}
+                      "propagation": {"type": "string"},
+                      "create_host_path": {"type": "boolean"}
                     },
                     "additionalProperties": false,
                     "patternProperties": {"^x-": {}}

--- a/spec.md
+++ b/spec.md
@@ -1811,6 +1811,9 @@ expressed in the short form.
 - `read_only`: flag to set the volume as read-only
 - `bind`: configure additional bind options
   - `propagation`: the propagation mode used for the bind
+  - `create_host_path`: create a directory at the source path on host if there is nothing present. 
+    Do nothing if there is something present at the path. This is automatically implied by short syntax
+    for backward compatibility with docker-compose legacy.
 - `volume`: configure additional volume options
   - `nocopy`: flag to disable copying of data from a container when a volume is created
 - `tmpfs`: configure additional tmpfs options


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce `create_host_path` as a volume bind options.

as explained on https://github.com/docker/compose-cli/pull/1563#issuecomment-826853661, for legacy reason short syntax binds will let moby container engine create source path on host, while the more recent mount API won't. Introducing this attribute allows to be more explicit on user intents, and can be automatically set when short syntax is used.



