### PR TITLE
document support for port's host_ip in "long syntax"

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -316,6 +316,7 @@
                 "type": "object",
                 "properties": {
                   "mode": {"type": "string"},
+                  "host_ip": {"type": "string"},
                   "target": {"type": "integer"},
                   "published": {"type": "integer"},
                   "protocol": {"type": "string"}

--- a/spec.md
+++ b/spec.md
@@ -1491,12 +1491,14 @@ expressed in the short form.
 
 - `target`: the container port
 - `published`: the publicly exposed port
+- `host_ip`: the Host IP mapping, unspecified means all network interfaces (`0.0.0.0`) 
 - `protocol`: the port protocol (`tcp` or `udp`), unspecified means any protocol
 - `mode`: `host` for publishing a host port on each node, or `ingress` for a port to be load balanced.
 
 ```yml
 ports:
   - target: 80
+    host_ip: 127.0.0.1
     published: 8080
     protocol: tcp
     mode: host


### PR DESCRIPTION
**What this PR does / why we need it**:
Document ability to configure host IP mapping for a port binding when using the "long syntax". Already documented for the "short syntax".

**Which issue(s) this PR fixes**:
see https://github.com/docker/compose-cli/issues/1701

