### PR TITLE
`missing` is a valid `pull_policy`

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -331,7 +331,7 @@
         "privileged": {"type": "boolean"},
         "profiles": {"$ref": "#/definitions/list_of_strings"},
         "pull_policy": {"type": "string", "enum": [
-          "always", "never", "if_not_present", "build"
+          "always", "never", "if_not_present", "build", "missing"
         ]},
         "read_only": {"type": "boolean"},
         "restart": {"type": "string"},


### PR DESCRIPTION
**What this PR does / why we need it**:
Looks like `missing` was introduced as the preferred alias for `if_not_present` in https://github.com/compose-spec/compose-spec/pull/136, but the change wasn't reflected in the spec. 

**Which issue(s) this PR fixes**:
Fixes #158.
