### PR TITLE
Allow use of plain boolean as environment values

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -770,7 +770,7 @@
           "type": "object",
           "patternProperties": {
             ".+": {
-              "type": ["string", "number", "null"]
+              "type": ["string", "number", "boolean", "null"]
             }
           },
           "additionalProperties": false

--- a/spec.md
+++ b/spec.md
@@ -754,7 +754,7 @@ VAR="quoted"
 ### environment
 
 `environment` defines environment variables set in the container. `environment` can use either an array or a
-map. Any boolean values; true, false, yes, no, MUST be enclosed in quotes to ensure
+map. Any boolean values; true, false, yes, no, SHOULD be enclosed in quotes to ensure
 they are not converted to True or False by the YAML parser.
 
 Environment variables MAY be declared by a single key (no value to equals sign). In such a case Compose


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't require use of quoted boolean as `environment` values
compose-go already manage boolean to string conversion, just the json schema validation block this usage.

**Which issue(s) this PR fixes**:
Fixes https://github.com/docker/compose-cli/issues/1975


