### PR TITLE
Clarify devices format

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -636,11 +636,13 @@ device_cgroup_rules:
 
 ### devices
 
-`devices` defines a list of device mappings for created containers.
+`devices` defines a list of device mappings for created containers in the form of
+`HOST_PATH:CONTAINER_PATH[:CGROUP_PERMISSIONS]`.
 
 ```yml
 devices:
   - "/dev/ttyUSB0:/dev/ttyUSB0"
+  - "/dev/sda:/dev/xvda:rwm"
 ```
 
 ### dns


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the description of `services.devices` to clarify which segment is the host path and which is the container path. It also indicates the optional third element, which is used to supply cgroup permissions and is supported by Docker Compose.

**Which issue(s) this PR fixes**:

NA (minor documentation enhancement).

