### PR TITLE
Clarify specification for external_links

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -989,9 +989,8 @@ Any other allowed keys in the service definition should be treated as scalars.
 
 ### external_links
 
-`external_links` link service containers to services managed outside this Compose application.
-`external_links` define the name of an existing service to retrieve using the platform lookup mechanism.
-An alias of the form `SERVICE:ALIAS` can be specified.
+`external_links` links service containers to containers managed outside this Compose application.
+An alias of the form `CONTAINER_NAME:ALIAS` can be specified.
 
 ```yml
 external_links:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the external_links specification to more accurately reflect the behavior of Docker Compose and the Docker engine.

**Which issue(s) this PR fixes**:
Fixes #195


