### PR TITLE
update maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -2,5 +2,5 @@ maintainers:
 - ndeloof
 - hangyan
 - justincormack 
-- kohidave
 - EricHripko
+- ulyssessouza


### PR DESCRIPTION
This updates the Compose Spec maintainers to reflect the actual status:

- David Killmon had no activity on the spec for months
- Ulysses Souza has been maintainer on docker-compose for years so is 200% legitimate to help us evolve the compose file format, in addition to the many contributions he made on compose-go.