### PR TITLE
define tmpfs.size as string or integer

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -427,8 +427,10 @@
                     "type": "object",
                     "properties": {
                       "size": {
-                        "type": "integer",
-                        "minimum": 0
+                        "oneOf": [
+                          {"type": "integer", "minimum": 0},
+                          {"type": "string"}
+                        ]
                       }
                     },
                     "additionalProperties": false,

--- a/spec.md
+++ b/spec.md
@@ -1819,7 +1819,7 @@ expressed in the short form.
 - `volume`: configure additional volume options
   - `nocopy`: flag to disable copying of data from a container when a volume is created
 - `tmpfs`: configure additional tmpfs options
-  - `size`: the size for the tmpfs mount in bytes
+  - `size`: the size for the tmpfs mount in bytes (either numeric or as bytes unit)
 - `consistency`: the consistency requirements of the mount. Available values are platform specific
 
 ### volumes_from


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow tmpfs.size to be defined as unit bytes notation (compatibility with compose file 2.x)

**Which issue(s) this PR fixes**:
fixes https://github.com/compose-spec/compose-spec/issues/204
see https://github.com/docker/compose/issues/8696