### PR TITLE
Update field order in services

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -248,9 +248,11 @@ available resources.
 Deploy support is an OPTIONAL aspect of the Compose specification, and is described in detail [here](deploy.md). If
 not implemented the Deploy section SHOULD be ignored and the Compose file MUST still be considered valid.
 
-### deploy
 
-`deploy` specifies the configuration for the deployment and lifecycle of services, as defined [here](deploy.md).
+### build
+
+`build` specifies the build configuration for creating container image from source, as defined [here](build.md).
+
 
 ### blkio_config
 
@@ -360,9 +362,6 @@ _DEPRECATED: use [deploy.reservations.cpus](deploy.md#cpus)_
 
 `cpuset` defines the explicit CPUs in which to allow execution. Can be a range `0-3` or a list `0,1`
 
-### build
-
-`build` specifies the build configuration for creating container image from source, as defined [here](build.md).
 
 ### cap_add
 
@@ -621,6 +620,12 @@ Compose implementations MUST guarantee dependency services have been started bef
 starting a dependent service.
 Compose implementations MUST guarantee dependency services marked with
 `service_healthy` are "healthy" before starting a dependent service.
+
+
+### deploy
+
+`deploy` specifies the configuration for the deployment and lifecycle of services, as defined [here](deploy.md).
+
 
 ### device_cgroup_rules
 


### PR DESCRIPTION
Signed-off-by: Hang Yan <hang.yan@hotmail.com>

**What this PR does / why we need it**:
Change the field order in services. I think the field order is confusing when I read it, `build` is in the middle of a series of `cpu` settintgs and not likely in alpha alphabetical  order. So i tweak it a little bit

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #


