### PR TITLE
Minor Spacing Adjustment

### DIFF
--- a/build.md
+++ b/build.md
@@ -64,8 +64,8 @@ services:
   backend:
     image: awesome/database
     build:
-        context: backend
-        dockerfile: ../backend.Dockerfile
+      context: backend
+      dockerfile: ../backend.Dockerfile
 
   custom:
     build: ~/custom


### PR DESCRIPTION
While not required by the spec the rest of the documents use 2 spaces for nesting in YAML code blocks. This snuck through at 4.

Signed-off-by: Tim Way <1091435+timway@users.noreply.github.com>

**What this PR does / why we need it**:
Just a minor readability tweak.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
I did not create an issue to correspond to this PR. Let me know if I should.