### PR TITLE
Make docker compose v2 the reference implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,14 @@ The specification and code is licensed under the Apache 2.0 license found in the
 
 ## Implementations
 
-* [docker-compose](https://github.com/docker/compose)
-* Docker CLI (`docker stack` command)
+[Docker Compose](https://github.com/docker/compose) is the Rerefence Implementation of the Compose Specification.
+
+Compose Specification is also implemented by:
+
 * [Kompose](https://github.com/kubernetes/kompose)
-* [containerd/nerdctl](https://github.com/containerd/nerdctl)
+* [Nerdctl](https://github.com/containerd/nerdctl)
 * [Okteto Stacks](https://okteto.com/docs/reference/stacks)
-* [docker/compose-cli](https://github.com/docker/compose-cli)
+* [Docker Cloud Integrations](https://github.com/docker/compose-cli)
 
 | Metadata |                  |
 | -------- | ---------------: |


### PR DESCRIPTION
**What this PR does / why we need it**:
Make Docker Compose v2 the reference implementation

**Which issue(s) this PR fixes**:
Close #212


