### PR TITLE
Add missing deploy.limits.pids (from schema 3.9), deprecate pids_limit

### DIFF
--- a/deploy.md
+++ b/deploy.md
@@ -143,6 +143,7 @@ services:
         limits:
           cpus: '0.50'
           memory: 50M
+          pids: 1
         reservations:
           cpus: '0.25'
           memory: 20M
@@ -155,6 +156,10 @@ services:
 #### memory
 
 `memory` configures a limit or reservation on the amount of memory a container can allocate, set as a string expressing a [byte value](spec.md#specifying-byte-values).
+
+#### pids
+
+`pids_limit` tunes a container’s PIDs limit, set as an integer.
 
 #### devices
 

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -519,7 +519,8 @@
               "type": "object",
               "properties": {
                 "cpus": {"type": ["number", "string"]},
-                "memory": {"type": "string"}
+                "memory": {"type": "string"},
+                "pids": {"type": "integer"}
               },
               "additionalProperties": false,
               "patternProperties": {"^x-": {}}

--- a/spec.md
+++ b/spec.md
@@ -1425,6 +1425,8 @@ Supported values are platform specific.
 
 ### pids_limit
 
+_DEPRECATED: use [deploy.reservations.pids](deploy.md#pids)_
+
 `pids_limit` tunes a container’s PIDs limit. Set to -1 for unlimited PIDs.
 
 ```yml


### PR DESCRIPTION
**What this PR does / why we need it**:

compose schema v3.9 added support for `deploy.limits.pids` (through https://github.com/docker/cli/commit/851eeb9639ddd5186c57db0533ede26964ee27cc (https://github.com/docker/cli/pull/2503)), however, work on compose-spec was already in progress, which lead to changes from the 3.9 schema to not be included.

This patch adds the missing option and mars the `services.{name}.pids_limit` as deprecated, similar to comparable limit- and reservation options (`services.{name}.cpus`, `services.{name}.mem_limit`, `services.{name}.mem_reservation`.


relates to https://github.com/moby/moby/issues/43056