### PR TITLE
Added volume bind option SELinux :z :Z

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -410,7 +410,8 @@
                     "type": "object",
                     "properties": {
                       "propagation": {"type": "string"},
-                      "create_host_path": {"type": "boolean"}
+                      "create_host_path": {"type": "boolean"},
+                      "selinux": {"type": "string", "enum": ["z", "Z"]}
                     },
                     "additionalProperties": false,
                     "patternProperties": {"^x-": {}}

--- a/spec.md
+++ b/spec.md
@@ -1793,12 +1793,15 @@ volumes:
 #### Short syntax
 
 The short syntax uses a single string with colon-separated values to specify a volume mount
-(`VOLUME:CONTAINER_PATH`), or an access mode (`VOLUME:CONTAINER:ACCESS_MODE`).
+(`VOLUME:CONTAINER_PATH`), or an access mode (`VOLUME:CONTAINER_PATH:ACCESS_MODE`).
 
-`VOLUME` MAY be either a host path on the platform hosting containers (bind mount) or a volume name.
-`ACCESS_MODE` is a comma-separated `,` list of options and MAY be set as read-only by using `ro`,
-read and write by using `rw` (default) or SELinux re-labeling bind mount option for shared host content
-access among multiple containers by using `z` or private and unshared access for other containers by using `Z`.
+- `VOLUME`: MAY be either a host path on the platform hosting containers (bind mount) or a volume name
+- `CONTAINER_PATH`: the path in the container where the volume is mounted
+- `ACCESS_MODE`: is a comma-separated `,` list of options and MAY be set to:
+  - `rw`: read and write access (default)
+  - `ro`: read-only access
+  - `z`: SELinux option indicates that the bind mount host content is shared among multiple containers
+  - `Z`: SELinux option indicates that the bind mount host content is private and unshared for other containers
 
 > **Note**: The SELinux re-labeling bind mount option is ignored on platforms without SELinux.
 

--- a/spec.md
+++ b/spec.md
@@ -1820,6 +1820,7 @@ expressed in the short form.
   - `create_host_path`: create a directory at the source path on host if there is nothing present. 
     Do nothing if there is something present at the path. This is automatically implied by short syntax
     for backward compatibility with docker-compose legacy.
+  - `selinux`: the SELinux re-labeling option `z` (shared) or `Z` (private)
 - `volume`: configure additional volume options
   - `nocopy`: flag to disable copying of data from a container when a volume is created
 - `tmpfs`: configure additional tmpfs options

--- a/spec.md
+++ b/spec.md
@@ -1796,7 +1796,11 @@ The short syntax uses a single string with colon-separated values to specify a v
 (`VOLUME:CONTAINER_PATH`), or an access mode (`VOLUME:CONTAINER:ACCESS_MODE`).
 
 `VOLUME` MAY be either a host path on the platform hosting containers (bind mount) or a volume name.
-`ACCESS_MODE` MAY be set as read-only by using `ro` or read and write by using `rw` (default).
+`ACCESS_MODE` is a comma-separated `,` list of options and MAY be set as read-only by using `ro`,
+read and write by using `rw` (default) or SELinux re-labeling bind mount option for shared host content
+access among multiple containers by using `z` or private and unshared access for other containers by using `Z`.
+
+> **Note**: The SELinux re-labeling bind mount option is ignored on platforms without SELinux.
 
 > **Note**: Relative host paths MUST only be supported by Compose implementations that deploy to a
 > local container runtime. This is because the relative path is resolved from the Compose file’s parent


### PR DESCRIPTION
**What this PR does / why we need it**:

Related with https://github.com/compose-spec/compose-go/pull/213

This feature describe the SELinux field for setting the `:z` or `:Z` bind option for relabeling SELinux label.

References:
- https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #191

Signed-off-by: Tymoteusz Blazejczyk <tymoteusz.blazejczyk@tymonx.com>