### PR TITLE
published port can be a range

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -318,7 +318,7 @@
                   "mode": {"type": "string"},
                   "host_ip": {"type": "string"},
                   "target": {"type": "integer"},
-                  "published": {"type": "integer"},
+                  "published": {"type": ["string", "integer"]},
                   "protocol": {"type": "string"}
                 },
                 "additionalProperties": false,

--- a/spec.md
+++ b/spec.md
@@ -1494,7 +1494,7 @@ The long form syntax allows the configuration of additional fields that can't be
 expressed in the short form.
 
 - `target`: the container port
-- `published`: the publicly exposed port
+- `published`: the publicly exposed port. Can be set as a range using syntax `start-end`, then actual port SHOULD be assigned within this range based on available ports.
 - `host_ip`: the Host IP mapping, unspecified means all network interfaces (`0.0.0.0`) 
 - `protocol`: the port protocol (`tcp` or `udp`), unspecified means any protocol
 - `mode`: `host` for publishing a host port on each node, or `ingress` for a port to be load balanced.
@@ -1504,6 +1504,12 @@ ports:
   - target: 80
     host_ip: 127.0.0.1
     published: 8080
+    protocol: tcp
+    mode: host
+
+  - target: 80
+    host_ip: 127.0.0.1
+    published: 8000-9000
     protocol: tcp
     mode: host
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes `published` a string so that it can be set with a range, not just a port number

**Which issue(s) this PR fixes**:
See https://github.com/docker/compose/issues/8530

