### PR TITLE
Fix pids limit key in docs

### DIFF
--- a/deploy.md
+++ b/deploy.md
@@ -159,7 +159,7 @@ services:
 
 #### pids
 
-`pids_limit` tunes a container’s PIDs limit, set as an integer.
+`pids` tunes a container’s PIDs limit, set as an integer.
 
 #### devices
 


### PR DESCRIPTION
Pasting previous description https://github.com/compose-spec/compose-spec/commit/e8db8022c0b2e3d5eb007d629ff684cbe49a17a4 caused the description to mention the previous (and now wrong) key

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #


