### PR TITLE
Add ssh to build

### DIFF
--- a/build.md
+++ b/build.md
@@ -163,7 +163,7 @@ args:
 * `default` - let the builder connect to the ssh-agent.
 * `ID=path` - a key/value definition of an ID and the associated path. Can be either a [PEM](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail) file, or path to ssh-agent socket
 
-Simple`default` sample
+Simple `default` sample
 ```yaml
 build:
   context: .
@@ -174,7 +174,7 @@ or
 ```yaml
 build:
   context: .
-  ssh: [default]   # mount the default ssh agent
+  ssh: ["default"]   # mount the default ssh agent
 ```
 
 Using a custom id `myproject` with path to a local SSH key:
@@ -185,7 +185,7 @@ build:
     - myproject=~/.ssh/myproject.pem
 ```
 Image builder can then rely on this to mount SSH key during build.
-For illustration, [Buildkit extended syntax](https://github.com/compose-spec/compose-spec/pull/234/%5Bmoby/buildkit@master/frontend/dockerfile/docs/syntax.md#run---mounttypessh%5D(https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypessh)) can be used to mount ssh key set by ID and access a secured resource:
+For illustration, [BuildKit extended syntax](https://github.com/compose-spec/compose-spec/pull/234/%5Bmoby/buildkit@master/frontend/dockerfile/docs/syntax.md#run---mounttypessh%5D(https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypessh)) can be used to mount ssh key set by ID and access a secured resource:
 
 `RUN --mount=type=ssh,id=myproject git clone ...`
 

--- a/build.md
+++ b/build.md
@@ -162,14 +162,6 @@ args:
 `ssh` property syntax can be either:
 * `default` - let the builder connect to the ssh-agent.
 * `ID=path` - a key/value definition of an ID and the associated path. Can be either a [PEM](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail) file, or path to ssh-agent socket
-* `{}` (no value) which is a shortcut of the `default` configuration
-
-`ssh` without any parameter
-```yaml
-build:
-  context: .
-  ssh:   # mount the default ssh agent
-```
 
 Simple`default` sample
 ```yaml

--- a/build.md
+++ b/build.md
@@ -157,7 +157,7 @@ args:
 
 ### ssh
 
-`ssh` defines an SSH authentication that the image builder SHOULD use during image build (e.g., cloning private repository)
+`ssh` defines SSH authentications that the image builder SHOULD use during image build (e.g., cloning private repository)
 
 `ssh` property syntax can be either:
 * `default` - let the builder connect to the ssh-agent.
@@ -167,13 +167,22 @@ Simple`default` sample
 ```yaml
 build:
   context: .
-  ssh: default   # mount the default ssh agent
+  ssh: 
+    - default   # mount the default ssh agent
 ```
+or 
+```yaml
+build:
+  context: .
+  ssh: [default]   # mount the default ssh agent
+```
+
 Using a custom id `myproject` with path to a local SSH key:
 ```yaml
 build:
   context: .
-  ssh: myproject=~/.ssh/myproject.pem
+  ssh: 
+    - myproject=~/.ssh/myproject.pem
 ```
 Image builder can then rely on this to mount SSH key during build.
 For illustration, [Buildkit extended syntax](https://github.com/compose-spec/compose-spec/pull/234/%5Bmoby/buildkit@master/frontend/dockerfile/docs/syntax.md#run---mounttypessh%5D(https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypessh)) can be used to mount ssh key set by ID and access a secured resource:

--- a/build.md
+++ b/build.md
@@ -161,8 +161,8 @@ args:
 
 `ssh` property syntax can be either:
 * `default` - let the builder connect to the ssh-agent.
-* `ID=socket` - a key/value definition of an ID and the associated socket
-* `ssh` without any value which is a shortcut of the `default` configuration
+* `ID=path` - a key/value definition of an ID and the associated path. Can be either a [PEM](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail) file, or path to ssh-agent socket
+* `{}` (no value) which is a shortcut of the `default` configuration
 
 `ssh` without any parameter
 ```yaml
@@ -177,12 +177,16 @@ build:
   context: .
   ssh: default   # mount the default ssh agent
 ```
-Using a custom id `myproject` which will be use in the Dockerfile (i.e., `RUN --mount=type=ssh,id=myproject git clone ...`)
+Using a custom id `myproject` with path to a local SSH key:
 ```yaml
 build:
   context: .
   ssh: myproject=~/.ssh/myproject.pem
 ```
+Image builder can then rely on this to mount SSH key during build.
+For illustration, [Buildkit extended syntax](https://github.com/compose-spec/compose-spec/pull/234/%5Bmoby/buildkit@master/frontend/dockerfile/docs/syntax.md#run---mounttypessh%5D(https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypessh)) can be used to mount ssh key set by ID and access a secured resource:
+
+`RUN --mount=type=ssh,id=myproject git clone ...`
 
 ### cache_from
 

--- a/build.md
+++ b/build.md
@@ -155,6 +155,33 @@ args:
   - GIT_COMMIT
 ```
 
+### ssh
+
+`ssh` defines an SSH authentication that the image builder SHOULD use during image build (e.g., cloning private repository)
+
+ssh property syntax MUST follow the global format `[default|<ID>[=<socket>|<KEY>[,<KEY>]]]`. 
+Using the `ssh` without any parameter or just `default` is actually a shortcut notation for `default=${SSH_AUTH_SOCK}`.
+
+`ssh` without any parameter
+```yaml
+build:
+  context: .
+  ssh:   # mount the default ssh agent
+```
+
+Simple`default` sample
+```yaml
+build:
+  context: .
+  ssh: default   # mount the default ssh agent
+```
+Using a custom id `myproject` which will be use in the Dockerfile (i.e., `RUN --mount=type=ssh,id=myproject git clone ...`)
+```yaml
+build:
+  context: .
+  ssh: myproject=~/.ssh/myproject.pem
+```
+
 ### cache_from
 
 `cache_from` defines a list of sources the Image builder SHOULD use for cache resolution.

--- a/build.md
+++ b/build.md
@@ -159,8 +159,10 @@ args:
 
 `ssh` defines an SSH authentication that the image builder SHOULD use during image build (e.g., cloning private repository)
 
-ssh property syntax MUST follow the global format `[default|<ID>[=<socket>|<KEY>[,<KEY>]]]`. 
-Using the `ssh` without any parameter or just `default` is actually a shortcut notation for `default=${SSH_AUTH_SOCK}`.
+`ssh` property syntax can be either:
+* `default` - let the builder connect to the ssh-agent.
+* `ID=socket` - a key/value definition of an ID and the associated socket
+* `ssh` without any value which is a shortcut of the `default` configuration
 
 `ssh` without any parameter
 ```yaml

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -91,12 +91,7 @@
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
-                "ssh": {
-                  "oneOf": [
-                    {"type": "string"},
-                    {"$ref": "#/definitions/list_or_dict"}
-                  ]
-                },
+                "ssh": {"$ref": "#/definitions/list_or_dict"},
                 "labels": {"$ref": "#/definitions/list_or_dict"},
                 "cache_from": {"type": "array", "items": {"type": "string"}},
                 "cache_to": {"type": "array", "items": {"type": "string"}},

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -91,7 +91,13 @@
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
-                "ssh": {"type": "string"},
+                "ssh": {
+                  "oneOf": [
+                    {},
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}}
+                  ]
+                },
                 "labels": {"$ref": "#/definitions/list_or_dict"},
                 "cache_from": {"type": "array", "items": {"type": "string"}},
                 "cache_to": {"type": "array", "items": {"type": "string"}},

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -93,9 +93,8 @@
                 "args": {"$ref": "#/definitions/list_or_dict"},
                 "ssh": {
                   "oneOf": [
-                    {},
                     {"type": "string"},
-                    {"type": "array", "items": {"type": "string"}}
+                    {"$ref": "#/definitions/list_or_dict"}
                   ]
                 },
                 "labels": {"$ref": "#/definitions/list_or_dict"},

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -91,6 +91,7 @@
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
+                "ssh": {"$ref": "#/definitions/string_or_list"},
                 "labels": {"$ref": "#/definitions/list_or_dict"},
                 "cache_from": {"type": "array", "items": {"type": "string"}},
                 "cache_to": {"type": "array", "items": {"type": "string"}},

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -91,7 +91,7 @@
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
-                "ssh": {"$ref": "#/definitions/string_or_list"},
+                "ssh": {"type": "string"},
                 "labels": {"$ref": "#/definitions/list_or_dict"},
                 "cache_from": {"type": "array", "items": {"type": "string"}},
                 "cache_to": {"type": "array", "items": {"type": "string"}},


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce `ssh` attribute to the `build` section.
This allows the usage of SSH authentification when building an image (i.e., cloning a private repo...)

**Which issue(s) this PR fixes**:
This PR is part of the #233 proposal


