### PR TITLE
Fix copy/paste config name typo in Configs section

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -2245,7 +2245,7 @@ configs:
     file: ./httpd.conf
 ```
 
-Alternatively, `http_config` can be declared as external, doing so Compose implementation will lookup `server-certificate` to expose configuration data to relevant services.
+Alternatively, `http_config` can be declared as external, doing so Compose implementation will lookup `http_config` to expose configuration data to relevant services.
 
 ```yml
 configs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Config name typo (``server-certificate` should be `http_config `)

**Which issue(s) this PR fixes**:
Fixes #230 


