### PR TITLE
Fix link to #secrets-top-level-element

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1606,7 +1606,7 @@ web:
 
 ### secrets
 
-`secrets` grants access to sensitive data defined by [secrets](secrets) on a per-service basis. Two
+`secrets` grants access to sensitive data defined by [secrets](#secrets-top-level-element) on a per-service basis. Two
 different syntax variants are supported: the short syntax and the long syntax.
 
 Compose implementations MUST report an error if the secret doesn't exist on the platform or isn't defined in the


### PR DESCRIPTION
**What this PR does / why we need it**:
Previous link results in a 404. Also, it attempts to point at the wrong location. The actual definition of secrets happens in the [#secrets-top-level-element](https://github.com/compose-spec/compose-spec/blob/master/spec.md#secrets-top-level-element).

**Which issue(s) this PR fixes**:
None


