### PR TITLE
Fix non-standard RFC 2119 key word usage

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1220,7 +1220,7 @@ if no alias was specified.
 Links are not required to enable services to communicate - when no specific network configuration is set,
 any service MUST be able to reach any other service at that service’s name on the `default` network. If services
 do declare networks they are attached to, `links` SHOULD NOT override the network configuration and services not
-attached to a shared network SHOULD NOT be able to communicate. Compose implementations MAY NOT warn the user
+attached to a shared network SHOULD NOT be able to communicate. Compose implementations MAY not warn the user
 about this configuration mismatch.
 
 Links also express implicit dependency between services in the same way as


### PR DESCRIPTION
Change "MAY NOT" to "MAY not" in links section

Signed-off-by: Guthrie McAfee Armstrong <guthrie.armstrong@gmail.com>

**What this PR does / why we need it**:
Edits the links section to use "MAY not" instead of "MAY NOT", since the latter is not defined by [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) and could be ambiguous.

**Which issue(s) this PR fixes**:
Fixes #242 (one of several possible fixes, refer to the issue before considering this change).