### PR TITLE
no sign-off needed for organisation members

### DIFF
--- a/.github/dco.yaml
+++ b/.github/dco.yaml
@@ -1,0 +1,2 @@
+require:
+  members: false


### PR DESCRIPTION
it will let us to easily merge PRs when we accept modifications directly from the GitHub UI


