### PR TITLE
Add support of tags in the build section

### DIFF
--- a/build.md
+++ b/build.md
@@ -390,7 +390,7 @@ the `image` [property defined in the service section](spec.md#image)
 ```yml
 tags:
   - "myimage:mytag"
-  "registry/username/myrepos:my-other-tag"
+  - "registry/username/myrepos:my-other-tag"
 ```
 
 ## Implementations

--- a/build.md
+++ b/build.md
@@ -382,6 +382,19 @@ Service builds MAY be granted access to multiple secrets. Long and short syntax 
 same Compose file. Defining a secret in the top-level `secrets` MUST NOT imply granting any service build access to it.
 Such grant must be explicit within service specification as [secrets](spec.md#secrets) service element.
 
+### tags
+
+`tags` defines a list of tag mappings that MUST be associated to the build image.
+
+```yml
+tags:
+  "myimage:mytag"
+  "registry/username/myrepos:my-other-tag"
+```
+
+Compose implementations MUST create matching entry with the IP address and hostname in the container's network
+configuration, which means for Linux `/etc/hosts` will get extra lines:
+
 ## Implementations
 
 * [docker-compose](https://docs.docker.com/compose)

--- a/build.md
+++ b/build.md
@@ -384,7 +384,7 @@ Such grant must be explicit within service specification as [secrets](spec.md#se
 
 ### tags
 
-`tags` defines a list of tag mappings that MUST be associated to the build image. This list come in addition of 
+`tags` defines a list of tag mappings that MUST be associated to the build image. This list comes in addition of 
 the `image` [property defined in the service section](spec.md#image)
 
 ```yml

--- a/build.md
+++ b/build.md
@@ -384,16 +384,14 @@ Such grant must be explicit within service specification as [secrets](spec.md#se
 
 ### tags
 
-`tags` defines a list of tag mappings that MUST be associated to the build image.
+`tags` defines a list of tag mappings that MUST be associated to the build image. This list come in addition of 
+the `image` [property defined in the service section](spec.md#image)
 
 ```yml
 tags:
-  "myimage:mytag"
+  - "myimage:mytag"
   "registry/username/myrepos:my-other-tag"
 ```
-
-Compose implementations MUST create matching entry with the IP address and hostname in the container's network
-configuration, which means for Linux `/etc/hosts` will get extra lines:
 
 ## Implementations
 

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -102,7 +102,8 @@
                 "shm_size": {"type": ["integer", "string"]},
                 "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
                 "isolation": {"type": "string"},
-                "secrets": {"$ref": "#/definitions/service_config_or_secret"}
+                "secrets": {"$ref": "#/definitions/service_config_or_secret"},
+                "tags":{"type": "array", "items": {"type": "string"}}
               },
               "additionalProperties": false,
               "patternProperties": {"^x-": {}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce `tags` attribute to the build section.
This allows to add a list of tags that would be associated to the build image

**Which issue(s) this PR fixes**:
This PR is part of the https://github.com/compose-spec/compose-spec/issues/233 proposal
