### PR TITLE
Add Guillaume Lours as a maintainer

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -4,3 +4,4 @@ maintainers:
 - justincormack 
 - EricHripko
 - ulyssessouza
+- glours


### PR DESCRIPTION
**What this PR does / why we need it**:
Guillaume Lours has been an active contributor on the compose-specification: https://github.com/compose-spec/compose-spec/commits/master?author=glours
he both has been reviewing proposals, and opened new propositions - he typically has been actively refreshing the `build` section to align with modern build features offered by buildKit.

I propose we make Guillaume an official spec maintainer
cc @EricHripko @ulyssessouza @justincormack @hangyan 

