### PR TITLE
tiny fix: change to a better link name, "deploy.limits.cpus"

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -374,7 +374,7 @@ an integer value using microseconds as unit or a [duration](#specifying-duration
 
 ### cpus
 
-_DEPRECATED: use [deploy.reservations.cpus](deploy.md#cpus)_
+_DEPRECATED: use [deploy.limits.cpus](deploy.md#cpus)_
 
 `cpus` define the number of (potentially virtual) CPUs to allocate to service containers. This is a fractional number.
 `0.000` means no limit.


### PR DESCRIPTION
**What this PR does / why we need it**:

I changed like below in `spec.md`.
- before: *DEPRECATED: use [deploy.reservations.cpus](https://docs.docker.com/compose/compose-file/deploy/#cpus)*
- after: *DEPRECATED: use [deploy.limits.cpus](https://docs.docker.com/compose/compose-file/deploy/#cpus)*

**What is the problem you're trying to solve**

[Compose specification \| Docker Documentation  | cpus ](https://docs.docker.com/compose/compose-file/#cpus)

The above link states that
> *DEPRECATED: use [deploy.reservations.cpus](https://docs.docker.com/compose/compose-file/deploy/#cpus)*
> `cpus` define the number of (potentially virtual) CPUs to allocate to service containers. This is a fractional number. `0.000` means no limit.

However, `reservations` means that ["The platform MUST guarantee container can allocate at least the configured amount"](https://docs.docker.com/compose/compose-file/deploy/#resources)
I think that `limits`, which means that ["The platform MUST prevent container to allocate more"](https://docs.docker.com/compose/compose-file/deploy/#resources), is more appropriate.


I have read the [`CONTRIBUTING.md`](https://github.com/compose-spec/compose-spec/blob/master/CONTRIBUTING.md), but am not familiar with the commit.
So, if there are any mistakes, feel free to let me know!

Signed-off-by: Akihide Ito <akihide.ito.dev@gmail.com>
