### PR TITLE
Typo: missing line in configs "short syntax" example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -458,6 +458,7 @@ services:
     image: redis:latest
     configs:
       - my_config
+      - my_other_config
 configs:
   my_config:
     file: ./my_config.txt


### PR DESCRIPTION
The paragraph above says "grant the `redis` service access to the `my_config` and `my_other_config` configs."  While `my_other_config` is defined, it is not added to the `redis` `configs` list.

I suspect this was a merge error or something.

To ensure I wasn't going crazy, I verified that at least Docker Compose v2 requires this line for the second config to be materialized inside the service.

**What this PR does / why we need it**:

It fixes a confusing typo in the spec; I read it three times before realizing the spec itself was broken. The typo fix also matches reality.

**Which issue(s) this PR fixes**:

Fixes #269 


