### PR TITLE
Mark published port as string

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1509,6 +1509,7 @@ ports:
   - "8000:8000"
   - "9090-9091:8080-8081"
   - "49100:22"
+  - "8000-9000:80"
   - "127.0.0.1:8001:8001"
   - "127.0.0.1:5000-5010:5000-5010"
   - "6060:6060/udp"
@@ -1523,7 +1524,7 @@ The long form syntax allows the configuration of additional fields that can't be
 expressed in the short form.
 
 - `target`: the container port
-- `published`: the publicly exposed port. Can be set as a range using syntax `start-end`, then actual port SHOULD be assigned within this range based on available ports.
+- `published`: the publicly exposed port. Can be set as a range using syntax `start-end`,so it is defined as a string, then actual port SHOULD be assigned within this range based on available ports.
 - `host_ip`: the Host IP mapping, unspecified means all network interfaces (`0.0.0.0`) 
 - `protocol`: the port protocol (`tcp` or `udp`), unspecified means any protocol
 - `mode`: `host` for publishing a host port on each node, or `ingress` for a port to be load balanced.
@@ -1532,13 +1533,13 @@ expressed in the short form.
 ports:
   - target: 80
     host_ip: 127.0.0.1
-    published: 8080
+    published: "8080"
     protocol: tcp
     mode: host
 
   - target: 80
     host_ip: 127.0.0.1
-    published: 8000-9000
+    published: "8000-9000"
     protocol: tcp
     mode: host
 ```

--- a/spec.md
+++ b/spec.md
@@ -1524,7 +1524,7 @@ The long form syntax allows the configuration of additional fields that can't be
 expressed in the short form.
 
 - `target`: the container port
-- `published`: the publicly exposed port. Can be set as a range using syntax `start-end`,so it is defined as a string, then actual port SHOULD be assigned within this range based on available ports.
+- `published`: the publicly exposed port. Can be set as a range using syntax `start-end`, so it is defined as a string, then actual port SHOULD be assigned within this range based on available ports.
 - `host_ip`: the Host IP mapping, unspecified means all network interfaces (`0.0.0.0`) 
 - `protocol`: the port protocol (`tcp` or `udp`), unspecified means any protocol
 - `mode`: `host` for publishing a host port on each node, or `ingress` for a port to be load balanced.


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the `ports.published` attribut description to explicitly indicate that a string format is expected, as the specification use the Yaml unquoted string feature some user may implicitly assume that only integer value are allowed.

**Which issue(s) this PR fixes**:
Fixes #262 and link to https://github.com/docker/compose/issues/9306


