### PR TITLE
Clarify secret.target absolute path syntax

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1645,7 +1645,7 @@ the service's containers.
 
 - `source`: The name of the secret as it exists on the platform.
 - `target`: The name of the file to be mounted in `/run/secrets/` in the
-  service's task containers. Defaults to `source` if not specified.
+  service's task container, or absolute path of the file if an alternate location is required. Defaults to `source` if not specified.
 - `uid` and `gid`: The numeric UID or GID that owns the file within
   `/run/secrets/` in the service's task containers. Default value is USER running container.
 - `mode`: The [permissions](http://permissions-calculator.org/) for the file to be mounted in `/run/secrets/`


### PR DESCRIPTION
**What this PR does / why we need it**:

The current spec does not define what happens if one specifies an absolute target path when specifying secrets. Specifying an absolute path is supported by Docker (at least) and works just fine.

**Which issue(s) this PR fixes**:

Fixes #161 (also #95 and #276)
