### PR TITLE
Document additional options for tmpfs

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1763,6 +1763,12 @@ tmpfs:
   - /tmp
 ```
 
+Additional options can be specified after a colon (`:`)
+
+```yml
+tmpfs: /run:rw,noexec,nosuid,size=65536k
+```
+
 ### tty
 
 `tty` configure service container to run with a TTY.


### PR DESCRIPTION
**What this PR does / why we need it**:

Add missing documentation for additional `tmpfs` options.

Example options where inspired by https://docs.docker.com/engine/reference/run/#tmpfs-mount-tmpfs-filesystems.

**Which issue(s) this PR fixes**:
Fixes docker/compose#10066


