### PR TITLE
introduce support for cgroup=host|private

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -140,6 +140,7 @@
         },
         "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cgroup": {"type": "string", "enum": ["host", "private"]},
         "cgroup_parent": {"type": "string"},
         "command": {
           "oneOf": [

--- a/spec.md
+++ b/spec.md
@@ -405,6 +405,14 @@ cap_drop:
   - SYS_ADMIN
 ```
 
+### cgroup
+
+`cgroup` specifies the cgroup namespace to join. When unset, it is container runtime decision to
+select cgroup namespace to use, if supported.
+
+- `host`: Run the container in the Container runtime cgroup namespace
+- `private`: Run the container in its own private cgroup namespace
+
 ### cgroup_parent
 
 `cgroup_parent` specifies an OPTIONAL parent [cgroup](http://man7.org/linux/man-pages/man7/cgroups.7.html) for the container.


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #148
see https://github.com/docker/compose/issues/8167


