### PR TITLE
add privileged attribute to build section

### DIFF
--- a/build.md
+++ b/build.md
@@ -250,6 +250,16 @@ configuration, which means for Linux `/etc/hosts` will get extra lines:
 `isolation` specifies a build’s container isolation technology. Like [isolation](spec.md#isolation) supported values
 are platform-specific.
 
+### privileged
+
+`privileged` configures the service image to build with elevated privileges. Support and actual impacts are platform-specific.
+
+```yml
+build:
+  context: .
+  privileged: true
+```
+
 ### labels
 
 `labels` add metadata to the resulting image. `labels` can be set either as an array or a map.

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -102,6 +102,7 @@
                 "shm_size": {"type": ["integer", "string"]},
                 "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
                 "isolation": {"type": "string"},
+                "privileged": {"type": "boolean"},
                 "secrets": {"$ref": "#/definitions/service_config_or_secret"},
                 "tags":{"type": "array", "items": {"type": "string"}}
               },


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What this PR does / why we need it**:
Add support of privileged mode when building service images

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #279 


