### PR TITLE
add missing build.platform in schema

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -104,7 +104,8 @@
                 "isolation": {"type": "string"},
                 "privileged": {"type": "boolean"},
                 "secrets": {"$ref": "#/definitions/service_config_or_secret"},
-                "tags":{"type": "array", "items": {"type": "string"}}
+                "tags": {"type": "array", "items": {"type": "string"}},
+                "platforms": {"type": "array", "items": {"type": "string"}}
               },
               "additionalProperties": false,
               "patternProperties": {"^x-": {}}


### PR DESCRIPTION
**What this PR does / why we need it**:
schema update was missing on https://github.com/compose-spec/compose-spec/pull/267


