### PR TITLE
Add support of `uts` in service definition

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -367,6 +367,7 @@
           }
         },
         "user": {"type": "string"},
+        "uts": {"type": "string"},
         "userns_mode": {"type": "string"},
         "volumes": {
           "type": "array",

--- a/spec.md
+++ b/spec.md
@@ -1177,6 +1177,17 @@ which MUST be implemented as described if supported:
     ipc: "service:[service name]"
 ```
 
+### uts
+
+`uts` configures the UTS namespace mode set for the service container. When unspecified
+it is the runtime's decision to assign a UTS namespace, if supported. Available values are:
+
+- `'host'` which results in the container using the same UTS namespace as the host.
+
+```yml
+    uts: "host"
+```
+
 ### isolation
 
 `isolation` specifies a container’s isolation technology. Supported values are platform-specific.


### PR DESCRIPTION
Signed-off-by: Laura Brehm <laurabrehm@hey.com>

**What this PR does / why we need it**:

Adds support of `uts` mode setting to service definition

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes https://github.com/compose-spec/compose-spec/issues/277
related to https://github.com/docker/compose/issues/3338
and https://github.com/docker/compose/issues/8408


