### PR TITLE
feat: add entities naming schema as top level attribute

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -16,6 +16,17 @@
       "description": "define the Compose project name, until user defines one explicitly."
     },
 
+    "naming_schema": {
+      "type": "object",
+      "id": "#/properties/naming_schema",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/naming_schema"
+        }
+      },
+      "additionalProperties": false
+    },
+
     "services": {
       "id": "#/properties/services",
       "type": "object",
@@ -75,6 +86,14 @@
   "additionalProperties": false,
 
   "definitions": {
+    "naming_schema": {
+      "id": "#/definitions/naming_schema",
+      "type": "object",
+      "properties": {
+        "prefix": {"type": "string"},
+        "suffix": {"type": "string"}
+      }
+    },
 
     "service": {
       "id": "#/definitions/service",

--- a/spec.md
+++ b/spec.md
@@ -243,6 +243,16 @@ services:
     command: echo "I'm running ${COMPOSE_PROJECT_NAME}"
 ```
 
+## Naming schema top-level element
+Top-level `naming_schema` property is defined by the specification as the containers and other entities, such as volumes, networks, etc..., naming schema.
+Compose implementations MUST offer a way for the user to override the prefix or add the suffix of the created entities' names.
+
+### Prefix
+`prefix` defines a custom prefix of the created entites' names.
+
+### Suffix
+`suffix` defines a custom suffix of the created entites' names.
+
 ## Services top-level element
 
 A Service is an abstract definition of a computing resource within an application which can be scaled/replaced


### PR DESCRIPTION
Signed-off-by: AhmedGrati <ahmedgrati1999@gmail.com>

**What this PR does / why we need it**:
This pull request aims to add a naming schema, by specifying the prefix and suffixes of the created entities' names.

A common use case for this is basically specifying no prefix for the created resources instead of the default prefix.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #301.


