### PR TITLE
Add `additional_contexts` to `build` section

### DIFF
--- a/build.md
+++ b/build.md
@@ -227,6 +227,36 @@ Cache target is defined using the same `type=TYPE[,KEY=VALUE]` syntax defined by
 
 Unsupported cache target MUST be ignored and not prevent user from building image.
 
+### additional_contexts
+
+`additional_contexts` defines a list of named contexts the image builder SHOULD use during image build.
+
+`additional_contexts` can be a mapping or a list:
+
+```yml
+build:
+  context: .
+  additional_contexts:
+    - resources=/path/to/resources
+    - app=docker-image://my-app:latest
+    - source=https://github.com/myuser/project.git
+```
+
+```yml
+build:
+  context: .
+  additional_contexts:
+    resources: /path/to/resources
+    app: docker-image://my-app:latest
+    source: https://github.com/myuser/project.git
+```
+
+When used as a list, the syntax should follow the `NAME=VALUE` format, where `VALUE` is a string. Validation beyond that is the responsibility of the image builder (and is builder specific).
+
+The Compose implementation SHOULD warn the user if the image builder does not support additional contexts and MAY list the unused contexts.
+
+Illustrative examples of how this is used in Buildx can be found [here](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#-additional-build-contexts---build-context).
+
 ### extra_hosts
 
 `extra_hosts` adds hostname mappings at build-time. Use the same syntax as [extra_hosts](spec.md#extra_hosts).

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -97,6 +97,7 @@
                 "cache_from": {"type": "array", "items": {"type": "string"}},
                 "cache_to": {"type": "array", "items": {"type": "string"}},
                 "no_cache": {"type": "boolean"},
+                "additional_contexts": {"$ref": "#/definitions/list_or_dict"},
                 "network": {"type": "string"},
                 "pull": {"type": "boolean"},
                 "target": {"type": "string"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for configuring additional/named contexts in the `build` section.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes https://github.com/compose-spec/compose-spec/issues/306


