### PR TITLE
cmd: update schema to account for empty overrides

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.json]
+indent_size = 2

--- a/05-services.md
+++ b/05-services.md
@@ -184,11 +184,16 @@ cgroup_parent: m-executor-abcd
 command: bundle exec thin -p 3000
 ```
 
-The command can also be a list, in a manner similar to [Dockerfile](https://docs.docker.com/engine/reference/builder/#cmd):
+The value can also be a list, in a manner similar to [Dockerfile](https://docs.docker.com/engine/reference/builder/#cmd):
 
 ```
 command: [ "bundle", "exec", "thin", "-p", "3000" ]
 ```
+
+If the value is `null`, the default command from the image MUST be used.
+
+If the value is `[]` (empty list) or `''` (empty string), the default command declared by the image MUST be ignored,
+i.e. overridden to be empty.
 
 ### configs
 
@@ -484,16 +489,20 @@ dns_search:
 
 ### entrypoint
 
-`entrypoint` overrides the default entrypoint for the Docker image (i.e. `ENTRYPOINT` set by Dockerfile).
-Compose implementations MUST clear out any default command on the Docker image - both `ENTRYPOINT` and `CMD` instruction
-in the Dockerfile - when `entrypoint` is configured by a Compose file. If [`command`](#command) is also set,
-it is used as parameter to `entrypoint` as a replacement for Docker image's `CMD`
+`entrypoint` declares the default entrypoint for the service container.
+This will override the `ENTRYPOINT` instruction from the service's Dockerfile.
 
+If `entrypoint` is non-null, Compose implementations MUST also ignore out any default command from the image (i.e. `CMD`
+instruction in Dockerfile).
+
+See also: [`command`](#command) to set or override the default command to be executed by the entrypoint process.
+
+In its short-form, the value can be defined as a string:
 ```yml
 entrypoint: /code/entrypoint.sh
 ```
 
-The entrypoint can also be a list, in a manner similar to
+Alternatively, the value can also be a list, in a manner similar to
 [Dockerfile](https://docs.docker.com/engine/reference/builder/#cmd):
 
 ```yml
@@ -505,6 +514,11 @@ entrypoint:
   - memory_limit=-1
   - vendor/bin/phpunit
 ```
+
+If the value is `null`, the default entrypoint from the image MUST be used.
+
+If the value is `[]` (empty list) or `''` (empty string), the default entrypoint declared by the image MUST be ignored,
+i.e. overridden to be empty.
 
 ### env_file
 
@@ -1681,4 +1695,3 @@ volumes_from:
 ### working_dir
 
 `working_dir` overrides the container's working directory from that specified by image (i.e. Dockerfile `WORKDIR`).
-

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -146,12 +146,7 @@
         "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cgroup": {"type": "string", "enum": ["host", "private"]},
         "cgroup_parent": {"type": "string"},
-        "command": {
-          "oneOf": [
-            {"type": "string"},
-            {"type": "array", "items": {"type": "string"}}
-          ]
-        },
+        "command": {"$ref": "#/definitions/command"},
         "configs": {"$ref": "#/definitions/service_config_or_secret"},
         "container_name": {"type": "string"},
         "cpu_count": {"type": "integer", "minimum": 0},
@@ -202,12 +197,7 @@
         "dns_opt": {"type": "array","items": {"type": "string"}, "uniqueItems": true},
         "dns_search": {"$ref": "#/definitions/string_or_list"},
         "domainname": {"type": "string"},
-        "entrypoint": {
-          "oneOf": [
-            {"type": "string"},
-            {"type": "array", "items": {"type": "string"}}
-          ]
-        },
+        "entrypoint": {"$ref": "#/definitions/command"},
         "env_file": {"$ref": "#/definitions/string_or_list"},
         "environment": {"$ref": "#/definitions/list_or_dict"},
 
@@ -736,6 +726,14 @@
       },
       "additionalProperties": false,
       "patternProperties": {"^x-": {}}
+    },
+
+    "command": {
+      "oneOf": [
+        {"type": "null"},
+        {"type": "string"},
+        {"type": "array","items": {"type": "string"}}
+      ]
     },
 
     "string_or_list": {

--- a/spec.md
+++ b/spec.md
@@ -429,17 +429,21 @@ cgroup_parent: m-executor-abcd
 
 ### command
 
-`command` overrides the default command declared by the container image (i.e. by Dockerfile's `CMD`).
+`command` overrides the default command declared by the image (i.e. by Dockerfile's `CMD`).
 
 ```
 command: bundle exec thin -p 3000
 ```
 
-The command can also be a list, in a manner similar to [Dockerfile](https://docs.docker.com/engine/reference/builder/#cmd):
+The value can also be a list, in a manner similar to [Dockerfile](https://docs.docker.com/engine/reference/builder/#cmd):
 
 ```
 command: [ "bundle", "exec", "thin", "-p", "3000" ]
 ```
+
+If the value is `null`, the default command from the image MUST be used.
+
+If the value is `[]` (emtpy list) or `''` (empty string), the default command declared by the image MUST be ignored, i.e. overridden to be empty.
 
 ### configs
 
@@ -735,16 +739,19 @@ dns_search:
 
 ### entrypoint
 
-`entrypoint` overrides the default entrypoint for the Docker image (i.e. `ENTRYPOINT` set by Dockerfile).
-Compose implementations MUST clear out any default command on the Docker image - both `ENTRYPOINT` and `CMD` instruction
-in the Dockerfile - when `entrypoint` is configured by a Compose file. If [`command`](#command) is also set,
-it is used as parameter to `entrypoint` as a replacement for Docker image's `CMD`
+`entrypoint` declares the default entrypoint for the service container.
+This will override the `ENTRYPOINT` instruction from the service's Dockerfile.
 
+If `entrypoint` is non-null, Compose implementations MUST also ignore out any default command from the image (i.e. `CMD` instruction in Dockerfile).
+
+See also: [`command`](#command) to set or override the default command to be executed by the entrypoint process.
+
+In its short-form, the value can be defined as a string:
 ```yml
 entrypoint: /code/entrypoint.sh
 ```
 
-The entrypoint can also be a list, in a manner similar to
+Alternatively, the value can also be a list, in a manner similar to
 [Dockerfile](https://docs.docker.com/engine/reference/builder/#cmd):
 
 ```yml
@@ -756,6 +763,10 @@ entrypoint:
   - memory_limit=-1
   - vendor/bin/phpunit
 ```
+
+If the value is `null`, the default entrypoint from the image MUST be used.
+
+If the value is `[]` (emtpy list) or `''` (empty string), the default entrypoint declared by the image MUST be ignored, i.e. overridden to be empty.
 
 ### env_file
 

--- a/spec.md
+++ b/spec.md
@@ -443,7 +443,8 @@ command: [ "bundle", "exec", "thin", "-p", "3000" ]
 
 If the value is `null`, the default command from the image MUST be used.
 
-If the value is `[]` (empty list) or `''` (empty string), the default command declared by the image MUST be ignored, i.e. overridden to be empty.
+If the value is `[]` (empty list) or `''` (empty string), the default command declared by the image MUST be ignored,
+i.e. overridden to be empty.
 
 ### configs
 
@@ -742,7 +743,8 @@ dns_search:
 `entrypoint` declares the default entrypoint for the service container.
 This will override the `ENTRYPOINT` instruction from the service's Dockerfile.
 
-If `entrypoint` is non-null, Compose implementations MUST also ignore out any default command from the image (i.e. `CMD` instruction in Dockerfile).
+If `entrypoint` is non-null, Compose implementations MUST also ignore out any default command from the image (i.e. `CMD`
+instruction in Dockerfile).
 
 See also: [`command`](#command) to set or override the default command to be executed by the entrypoint process.
 
@@ -766,7 +768,8 @@ entrypoint:
 
 If the value is `null`, the default entrypoint from the image MUST be used.
 
-If the value is `[]` (empty list) or `''` (empty string), the default entrypoint declared by the image MUST be ignored, i.e. overridden to be empty.
+If the value is `[]` (empty list) or `''` (empty string), the default entrypoint declared by the image MUST be ignored,
+i.e. overridden to be empty.
 
 ### env_file
 
@@ -1943,7 +1946,6 @@ volumes_from:
 ### working_dir
 
 `working_dir` overrides the container's working directory from that specified by image (i.e. Dockerfile `WORKDIR`).
-
 
 ## Networks top-level element
 

--- a/spec.md
+++ b/spec.md
@@ -443,7 +443,7 @@ command: [ "bundle", "exec", "thin", "-p", "3000" ]
 
 If the value is `null`, the default command from the image MUST be used.
 
-If the value is `[]` (emtpy list) or `''` (empty string), the default command declared by the image MUST be ignored, i.e. overridden to be empty.
+If the value is `[]` (empty list) or `''` (empty string), the default command declared by the image MUST be ignored, i.e. overridden to be empty.
 
 ### configs
 
@@ -766,7 +766,7 @@ entrypoint:
 
 If the value is `null`, the default entrypoint from the image MUST be used.
 
-If the value is `[]` (emtpy list) or `''` (empty string), the default entrypoint declared by the image MUST be ignored, i.e. overridden to be empty.
+If the value is `[]` (empty list) or `''` (empty string), the default entrypoint declared by the image MUST be ignored, i.e. overridden to be empty.
 
 ### env_file
 

--- a/spec.md
+++ b/spec.md
@@ -429,7 +429,7 @@ cgroup_parent: m-executor-abcd
 
 ### command
 
-`command` overrides the default command declared by the image (i.e. by Dockerfile's `CMD`).
+`command` overrides the default command declared by the container image (i.e. by Dockerfile's `CMD`).
 
 ```
 command: bundle exec thin -p 3000


### PR DESCRIPTION
* Clarify behavior around ignoring/clearing a base entrypoint or command using an empty list (`[]`) or emtpy string (`''`)
* Clarify handling of explicit `null` in commands
* Update schema to allow explicit `null` & use common type


