### PR TITLE
add Milas as maintainer of the specification

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -5,3 +5,4 @@ maintainers:
 - EricHripko
 - ulyssessouza
 - glours
+- milas


### PR DESCRIPTION
**What this PR does / why we need it**:
Milas Bowman (@milas) has been reviewing proposals, and opened new propositions - As we're lacking of maintainers, his previous experience as Tilt's engineer and now as Docker Compose maintainer makes him a good candidate to help us managing the Specification.

I propose we make Milas an official spec maintainer
cc @EricHripko @ulyssessouza @justincormack @hangyan @ndeloof 


