### PR TITLE
Require normalized project names

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -13,6 +13,7 @@
 
     "name": {
       "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_-]*$",
       "description": "define the Compose project name, until user defines one explicitly."
     },
 

--- a/spec.md
+++ b/spec.md
@@ -51,6 +51,8 @@ set the label `com.docker.compose.project`.
 
 Project name can be set explicitly by top-level `name` attribute. Compose implementation MUST offer a way for user to set a custom project name and override this name, so that the same `compose.yaml` file can be deployed twice on the same infrastructure, without changes, by just passing a distinct name.
 
+Project name MUST contain only lowercase letters, decimal digits, dashes, and underscores, and MUST begin with a lowercase letter or decimal digit.
+
 ### Illustrative example
 
 The following example illustrates Compose specification concepts with a concrete example application. The example is non-normative.


### PR DESCRIPTION
**What this PR does / why we need it**:

This brings the compose-spec in line with current `docker compose` behavior regarding acceptable project names.

compose-spec/compose-go#261 changed `docker compose` behavior to require normalized project names as input, instead of normalizing project names automatically. This landed in compose-spec/compose-go v1.2.5 and docker/compose v2.5.1.

However, the current error message "... is not a valid project name" gives no indication why a name isn't valid. This is surprising for users whose previously working project names no longer work with newer versions of `docker compose`. The valid format also isn't yet documented anywhere.

This is the first step towards documenting the valid format. If this change lands, I can follow up with corresponding changes to:

- https://docs.docker.com/compose/reference/#use--p-to-specify-a-project-name
- https://docs.docker.com/compose/environment-variables/envvars/#compose_project_name
- https://docs.docker.com/engine/reference/commandline/compose/#use--p-to-specify-a-project-name

I also plan to try updating `WithName` from cli/options.go in the compose-spec/compose-go repo to expand upon the error message.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #311.

Fixes docker/compose#9741.