### PR TITLE
introduce dockerfile-inline

### DIFF
--- a/build.md
+++ b/build.md
@@ -112,13 +112,30 @@ build:
 
 `dockerfile` allows to set an alternate Dockerfile. A relative path MUST be resolved from the build context.
 Compose implementations MUST warn user about absolute path used to define Dockerfile as those prevent Compose file
-from being portable.
+from being portable. When set, `dockerfile_inline` attribute is not allowed and a Compose Implementation SHOULD 
+reject any Compose file having both set.
 
 ```yml
 build:
   context: .
   dockerfile: webapp.Dockerfile
 ```
+
+### dockerfile_inline
+
+`dockerfile_inline` allows to define Dockerfile content as inlined string in a Compose file. When set, `dockerfile` 
+attribute is not allowed  and a Compose Implementation SHOULD reject any Compose file having both set.
+
+Use of YAML multi-line string syntax is recommended to define Dockerfile content:
+
+```yml
+build:
+  context: .
+  dockerfile_inline: |
+    FROM baseimage
+    RUN some command
+```
+
 
 ### args
 

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -91,6 +91,7 @@
               "properties": {
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
+                "dockerfile_inline": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
                 "ssh": {"$ref": "#/definitions/list_or_dict"},
                 "labels": {"$ref": "#/definitions/list_or_dict"},


### PR DESCRIPTION
**What this PR does / why we need it**:
define `dockerfile_inline` for user to declare a (simple) Dockerfile as inlined content directly in a compose-file.
attribute named has been chosen to align with bake's dockerfile-inline https://docs.docker.com/build/bake/file-definition/ but using underscore separator for consistency with other attributes


**Which issue(s) this PR fixes**:
Fixes https://github.com/compose-spec/compose-spec/issues/298


