### PR TITLE
clarification on interpolation

### DIFF
--- a/12-interpolation.md
+++ b/12-interpolation.md
@@ -43,3 +43,22 @@ the user and substitute the variable with an empty string.
 
 As any values in a Compose file can be interpolated with variable substitution, including compact string notation
 for complex elements, interpolation MUST be applied _before_ merge on a per-file-basis.
+
+Interpolation only applies to yaml VALUES, not KEYS. For the few places where keys are actually arbitrary strings defines
+by the user, like [labels](#labels) or [environment](#environment), alternate syntax with equal sign MUST be used to 
+get interpolation applied:
+
+```yml
+services:
+  foo:
+    labels: 
+      "$VAR_NOT_INTERPOLATED_BY_COMPOSE": "BAR"
+```
+
+```yml
+services:
+  foo:
+    labels: 
+      - "$VAR_INTERPOLATED_BY_COMPOSE=BAR"
+```
+

--- a/spec.md
+++ b/spec.md
@@ -2569,3 +2569,22 @@ the user and substitute the variable with an empty string.
 
 As any values in a Compose file can be interpolated with variable substitution, including compact string notation
 for complex elements, interpolation MUST be applied _before_ merge on a per-file-basis.
+
+Interpolation only applies to yaml VALUES, not KEYS. For the few places where keys are actually arbitrary strings defines
+by the user, like [labels](#labels) or [environment](#environment), alternate syntax with equal sign MUST be used to 
+get interpolation applied:
+
+```yml
+services:
+  foo:
+    labels: 
+      "$VAR_NOT_INTERPOLATED_BY_COMPOSE": "BAR"
+```
+
+```yml
+services:
+  foo:
+    labels: 
+      - "$VAR_INTERPOLATED_BY_COMPOSE=BAR"
+```
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Better document (lack of) interpolation on yaml KEYs, and workaround using "list of string" syntax

**Which issue(s) this PR fixes**:
Fixes https://github.com/compose-spec/compose-go/issues/241


