### PR TITLE
Add `annotations`

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -664,7 +664,7 @@ specified by `extends`) MUST be merged in the following way:
 
 ##### Mappings
 
-The following keys should be treated as mappings: `build.args`, `build.labels`,
+The following keys should be treated as mappings: `annotations`, `build.args`, `build.labels`,
 `build.extra_hosts`, `deploy.labels`, `deploy.update_config`, `deploy.rollback_config`,
 `deploy.restart_policy`, `deploy.resources.limits`, `environment`, `healthcheck`,
 `labels`, `logging.options`, `sysctls`, `storage_opt`, `extra_hosts`, `ulimits`.
@@ -797,6 +797,20 @@ duplicates resulting from the merge are not removed.
 ##### Scalars
 
 Any other allowed keys in the service definition should be treated as scalars.
+
+### annotations
+
+`annotations` defines annotations for the container. `annotations` can use either an array or a map.
+
+```yml
+annotations:
+  com.example.foo: bar
+```
+
+```yml
+annotations:
+  - com.example.foo=bar
+```
 
 ### external_links
 

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -83,6 +83,7 @@
 
       "properties": {
         "deploy": {"$ref": "#/definitions/deployment"},
+        "annotations": {"$ref": "#/definitions/list_or_dict"},
         "build": {
           "oneOf": [
             {"type": "string"},

--- a/spec.md
+++ b/spec.md
@@ -915,7 +915,7 @@ specified by `extends`) MUST be merged in the following way:
 
 ##### Mappings
 
-The following keys should be treated as mappings: `build.args`, `build.labels`,
+The following keys should be treated as mappings: `annotations`, `build.args`, `build.labels`,
 `build.extra_hosts`, `deploy.labels`, `deploy.update_config`, `deploy.rollback_config`,
 `deploy.restart_policy`, `deploy.resources.limits`, `environment`, `healthcheck`,
 `labels`, `logging.options`, `sysctls`, `storage_opt`, `extra_hosts`, `ulimits`.
@@ -1048,6 +1048,20 @@ duplicates resulting from the merge are not removed.
 ##### Scalars
 
 Any other allowed keys in the service definition should be treated as scalars.
+
+### annotations
+
+`annotations` defines annotations for the container. `annotations` can use either an array or a map.
+
+```yml
+annotations:
+  com.example.foo: bar
+```
+
+```yml
+annotations:
+  - com.example.foo=bar
+```
 
 ### external_links
 


### PR DESCRIPTION


**What this PR does / why we need it**:
Support setting OCI annotations.

Corresponds to `docker run --annotation KEY=VAL`:
- docker/cli#4156
- moby/moby#45025

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #331


