### PR TITLE
add Laura as maintainer of the specification

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -6,3 +6,4 @@ maintainers:
 - ulyssessouza
 - glours
 - milas
+- laurazard


### PR DESCRIPTION
**What this PR does / why we need it**:
Laura Brehm (@laurazard) has been reviewing proposals and contributed to spec improvements, including fixing compose-go library - As an active Docker Compose maintainer she's a good candidate to help us managing the Specification.

I propose we make Laura an official spec maintainer
cc @EricHripko @ulyssessouza @glours @ndeloof @milas 


