### PR TITLE
introduce ability for override to reset value to null/default

### DIFF
--- a/13-merge.md
+++ b/13-merge.md
@@ -131,5 +131,30 @@ services:
       - bar:/work
 ```
 
+### Reset value
 
+In addition to the previously described mechanism, an override Compose file can also be used to remove elements from application model.
+For this purpose, custom YAML tag `!reset` can be set to override value set by the overriden Compose file, and replace with default
+value or `null` on target attribute.
 
+Merging the following example YAML trees:
+```yaml
+services:
+  foo:
+    build:
+      context: /path
+```    
+
+```yaml
+services:
+  foo:
+    build: !reset
+```
+
+MUST result in a Compose application model equivalent to the YAML tree:
+
+```yaml
+services:
+  foo:
+    build: null
+```

--- a/spec.md
+++ b/spec.md
@@ -2721,5 +2721,30 @@ services:
       - bar:/work
 ```
 
+### Reset value
 
+In addition to the previously described mechanism, an override Compose file can also be used to remove elements from application model.
+For this purpose, custom YAML tag `!reset` can be set to override value set by the overriden Compose file, and replace with default
+value or `null` on target attribute.
 
+Merging the following example YAML trees:
+```yaml
+services:
+  foo:
+    build:
+      context: /path
+```    
+
+```yaml
+services:
+  foo:
+    build: !reset
+```
+
+MUST result in a Compose application model equivalent to the YAML tree:
+
+```yaml
+services:
+  foo:
+    build: null
+```


### PR DESCRIPTION
This proposal aims to let user defines attributes to be reset to null/default value from an override file


**Which issue(s) this PR fixes**:
Fixes # https://github.com/compose-spec/compose-spec/issues/284

proposed implementation: https://github.com/compose-spec/compose-go/pull/380


