### PR TITLE
convert diagram to mermaid

### DIFF
--- a/02-model.md
+++ b/02-model.md
@@ -34,20 +34,19 @@ The backend stores data in a persistent volume.
 
 Both services communicate with each other on an isolated back-tier network, while frontend is also connected to a front-tier network and exposes port 443 for external usage.
 
-```
-(External user) --> 443 [frontend network]
-                            |
-                  +--------------------+
-                  |  frontend service  |...ro...<HTTP configuration>
-                  |      "webapp"      |...ro...<server certificate> #secured
-                  +--------------------+
-                            |
-                        [backend network]
-                            |
-                  +--------------------+
-                  |  backend service   |  r+w   ___________________
-                  |     "database"     |=======( persistent volume )
-                  +--------------------+        \_________________/
+```mermaid
+flowchart TB;
+      A(((External user))) === B{{fa:fa-network-wired public network}};
+      B === |443| C(fa:fa-server frontend service 'webapp');
+      C:::service --- |ro| D> fa:fa-gear HTTP configuration ];
+      C --- |ro| E> fa:fa-key server certificate];
+      C === F{{fa:fa-network-wired private network}};
+      F === G(fa:fa-server backend service 'database');
+      G:::service --- |r+w| H[(fa:fa-floppy-disk persistent volume)];
+      
+      style A fill:#ffd
+      style H fill:#f96,stroke:#000
+      classDef service fill:#def,stroke:#000      
 ```
 
 The example application is composed of the following parts:

--- a/spec.md
+++ b/spec.md
@@ -69,20 +69,19 @@ The backend stores data in a persistent volume.
 
 Both services communicate with each other on an isolated back-tier network, while frontend is also connected to a front-tier network and exposes port 443 for external usage.
 
-```
-(External user) --> 443 [frontend network]
-                            |
-                  +--------------------+
-                  |  frontend service  |...ro...<HTTP configuration>
-                  |      "webapp"      |...ro...<server certificate> #secured
-                  +--------------------+
-                            |
-                        [backend network]
-                            |
-                  +--------------------+
-                  |  backend service   |  r+w   ___________________
-                  |     "database"     |=======( persistent volume )
-                  +--------------------+        \_________________/
+```mermaid
+flowchart TB;
+      A(((External user))) === B{{fa:fa-network-wired public network}};
+      B === |443| C(fa:fa-server frontend service 'webapp');
+      C:::service --- |ro| D> fa:fa-gear HTTP configuration ];
+      C --- |ro| E> fa:fa-key server certificate];
+      C === F{{fa:fa-network-wired private network}};
+      F === G(fa:fa-server backend service 'database');
+      G:::service --- |r+w| H[(fa:fa-floppy-disk persistent volume)];
+      
+      style A fill:#ffd
+      style H fill:#f96,stroke:#000
+      classDef service fill:#def,stroke:#000      
 ```
 
 The example application is composed of the following parts:
@@ -380,7 +379,7 @@ an integer value using microseconds as unit or a [duration](11-extension.md#spec
 
 ### cpus
 
-_DEPRECATED: use [deploy.limits.cpus](deploy.md#cpus)_
+_DEPRECATED: use [deploy.reservations.cpus](deploy.md#cpus)_
 
 `cpus` define the number of (potentially virtual) CPUs to allocate to service containers. This is a fractional number.
 `0.000` means no limit.


### PR DESCRIPTION
**What this PR does / why we need it**:
use mermaid to define the model diagram, which renders as a (reasonably) nice image on github, but still is easy to compare on pull request for maintenance - actually way easier to edit and compare than ASCII-art based diagram
Can be edited using https://mermaid.live/ for those not comfortable with the syntax

see result on https://github.com/ndeloof/compose-spec/blob/mermaid/02-model.md

**Which issue(s) this PR fixes**:
As suggested by discussions on https://github.com/compose-spec/compose-spec/pull/342


