### PR TITLE
fixing format of codeblock

### DIFF
--- a/build.md
+++ b/build.md
@@ -490,6 +490,7 @@ platform, otherwise users won't be able to run images they built.
 Compose implementations SHOULD report an error in the following cases:
 * when the list contains multiple platforms but the implementation is incapable of storing multi-platform images
 * when the list contains an unsupported platform
+
 ```yml
 build:
   context: "."
@@ -498,6 +499,7 @@ build:
     - "unsupported/unsupported"
 ```
 * when the list is non-empty and does not contain the service's platform
+
 ```yml
 services:
   frontend:


### PR DESCRIPTION
in the rest of the file the codeblocks are seperated by the rest of the text by a blank line. As is usually best practice. However in this section it wasn't seperated by a blank line.

I changed the format by inserting a blank line to match the rest of the file

**What this PR does / why we need it**: 
On https://docs.docker.com/compose/compose-file/build/ the code-block was rendered incorrectly, but only at this one code-block.  

---

A screenshot of the wrongly rendered section is attached below:

<img width="759" alt="image" src="https://github.com/compose-spec/compose-spec/assets/117523783/500bacaa-b37a-43b5-a0e6-376732a5294a">

---

I assume, that it might relate to this code-block not being seperated from the text by a blank line.
And even if not, approving this merge request might improve readability for those who might read this in a txt-Editor, and improve the consistency of this file.
However, if this behaviour is intended feel free to reject this merge request.

**Which issue(s) this PR fixes**: I didn't find an issue relating to this. As this is an minor change, it should not need a issue associated (as stated by contributing guidelines).


