### PR TITLE
add Windows drive prefix to temp directory path to be sure Makefile works with Git Bash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/*.json
 _site/
+out/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+DRIVE_PREFIX?=
+ifeq ($(OS), Windows_NT)
+	DRIVE_PREFIX=C:
+endif
 .PHONY: spec
 spec: ## generate spec.md file
 	$(eval $@_TMP_OUT := $(shell mktemp -d -t composespec-output.XXXXXXXXXX))
@@ -6,8 +10,8 @@ spec: ## generate spec.md file
 	-f ./Dockerfile \
 	--target spec-update
 	rm -f spec.md
-	cp -R "$($@_TMP_OUT)"/out/spec.md ./spec.md
-	rm -rf "$($@_TMP_OUT)"/*
+	cp -R "$(DRIVE_PREFIX)$($@_TMP_OUT)"/out/spec.md ./spec.md
+	rm -rf "$(DRIVE_PREFIX)$($@_TMP_OUT)"/*
 
 .PHONY: validate-spec
 validate-spec: ## validate the spec.md does not change


### PR DESCRIPTION
**What this PR does / why we need it**:
Add Windows drive prefix to temp directory when executing a shell command like `cp` or `rm`

At least Makefile will work with Git Bash


