### PR TITLE
introduce remove to configure runtime autoremove for service containers

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -1393,6 +1393,14 @@ If `pull_policy` and `build` are both present, Compose implementations SHOULD bu
 
 `read_only` configures service container to be created with a read-only filesystem.
 
+### remove
+
+When set to `true`, `remove` will configure platform to automatically remove the
+resource when the process exits. This has no effect if `restart` is set.
+
+Service continuity MAY be affected, as resource is removed before Compose implementation
+can react to process termination. Typically, anonymous volumes will be lost.
+
 ### restart
 
 `restart` defines the policy that the platform will apply on container termination.

--- a/spec.md
+++ b/spec.md
@@ -1662,6 +1662,14 @@ If `pull_policy` and `build` are both present, Compose implementations SHOULD bu
 
 `read_only` configures service container to be created with a read-only filesystem.
 
+### remove
+
+When set to `true`, `remove` will configure platform to automatically remove the
+resource when the process exits. This has no effect if `restart` is set.
+
+Service continuity MAY be affected, as resource is removed before Compose implementation
+can react to process termination. Typically, anonymous volumes will be lost.
+
 ### restart
 
 `restart` defines the policy that the platform will apply on container termination.


### PR DESCRIPTION
**What this PR does / why we need it**:
introduce `remove` to configure runtime autoremove for service containers

**Which issue(s) this PR fixes**:
Fixes https://github.com/docker/compose/issues/10688


