### PR TITLE
introduce `service.attach`

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -24,6 +24,13 @@ Deploy support is an optional aspect of the Compose specification, and is
 described in detail in the [Deployment support](deploy.md) documentation.
 If not implemented the Deploy section should be ignored and the Compose file must still be considered valid.
 
+### attach
+
+When `attach` is defined and set to `false` Compose will not collect service logs,
+until user explicitly requests to.
+
+Default service configuration is `attach: true`.
+
 ### build
 
 `build` specifies the build configuration for creating container image from source, as defined in the [Build support](build.md) documentation.

--- a/spec.md
+++ b/spec.md
@@ -235,6 +235,13 @@ Deploy support is an optional aspect of the Compose specification, and is
 described in detail in the [Deployment support](deploy.md) documentation.
 If not implemented the Deploy section should be ignored and the Compose file must still be considered valid.
 
+### attach
+
+When `attach` is defined and set to `false` Compose will not collect service logs,
+until user explicitly requests to.
+
+Default service configuration is `attach: true`.
+
 ### build
 
 `build` specifies the build configuration for creating container image from source, as defined in the [Build support](build.md) documentation.


### PR DESCRIPTION
**What this PR does / why we need it**:
introduce `attach` so a verbose utility service can be configured to be ignored when collecting output by setting `attach: false`. Defaults to `attach: true`.

demonstration usage on https://github.com/docker/compose/pull/10700

**Which issue(s) this PR fixes**:
see https://github.com/docker/compose/issues/10695

