### PR TITLE
Update spec.md

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -2084,7 +2084,7 @@ networks:
 
 ### ipam
 
-`ipam` specifies custom a IPAM configuration. This is an object with several properties, each of which is optional:
+`ipam` specifies a custom IPAM configuration. This is an object with several properties, each of which is optional:
 
 - `driver`: Custom IPAM driver, instead of the default.
 - `config`: A list with zero or more configuration elements, each containing:


### PR DESCRIPTION
Correct minor typo in `ipam` description section.

**What this PR does / why we need it**:
Corrects in minor typo in the compose specification document.

