### PR TITLE
Add aevesdocker as an official maintainer

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -7,3 +7,4 @@ maintainers:
 - glours
 - milas
 - laurazard
+- aevesdocker


### PR DESCRIPTION
**What this PR does / why we need it**:
I propose to add @aevesdocker as an official maintainer of the specification, the current work done by Allie to improve the readability of the Specification is just amazing! 
And having a professional Tech Writer as part of the Specification maintainers will be, IHMO, a great addition to the team



