### PR TITLE
Add volume type, cluster to service level volume type list

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -1671,7 +1671,7 @@ The short syntax uses a single string with colon-separated values to specify a v
 The long form syntax allows the configuration of additional fields that can't be
 expressed in the short form.
 
-- `type`: the mount type `volume`, `bind`, `tmpfs` or `npipe`
+- `type`: the mount type `volume`, `bind`, `tmpfs`, `npipe`, or `cluster`
 - `source`: the source of the mount, a path on the host for a bind mount, or the
   name of a volume defined in the
   [top-level `volumes` key](07-volumes.md). Not applicable for a tmpfs mount.

--- a/spec.md
+++ b/spec.md
@@ -1882,7 +1882,7 @@ The short syntax uses a single string with colon-separated values to specify a v
 The long form syntax allows the configuration of additional fields that can't be
 expressed in the short form.
 
-- `type`: the mount type `volume`, `bind`, `tmpfs` or `npipe`
+- `type`: the mount type `volume`, `bind`, `tmpfs`, `npipe`, or `cluster`
 - `source`: the source of the mount, a path on the host for a bind mount, or the
   name of a volume defined in the
   [top-level `volumes` key](07-volumes.md). Not applicable for a tmpfs mount.


### PR DESCRIPTION
**What this PR does / why we need it**:

[Cluster volumes](https://github.com/moby/moby/blob/master/docs/cluster_volumes.md) were added to docker SwarmKit in [23.0 of docker engine](https://github.com/docker/docs/blob/6dd952275680cf6f740058f1c0cf0b2e4e25f2ee/engine/release-notes/23.0.md?plain=1#L229). In short, cluster volumes enable use of container storage interface (CSI) volumes through docker's plugin system. This volume type can be specified at the service level under the volumes key as a volume's type.

Related to https://github.com/compose-spec/compose-go/pull/422

