### PR TITLE
add required attribute depends_on

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -386,6 +386,8 @@ expressed in the short form.
     service.
   - `service_completed_successfully`: specifies that a dependency is expected to run
     to successful completion before starting a dependent service.
+- `required`: when `false` Compose only warns you when the dependency service isn't started or available. If not defined
+    the default value of `required` is `true`.
 
 Service dependencies cause the following behaviors:
 

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -191,6 +191,10 @@
                   "additionalProperties": false,
                   "properties": {
                     "restart": {"type": "boolean"},
+                    "required": {
+                      "type":  "boolean",
+                      "default": true
+                    },
                     "condition": {
                       "type": "string",
                       "enum": ["service_started", "service_healthy", "service_completed_successfully"]

--- a/spec.md
+++ b/spec.md
@@ -597,6 +597,8 @@ expressed in the short form.
     service.
   - `service_completed_successfully`: specifies that a dependency is expected to run
     to successful completion before starting a dependent service.
+- `required`: when `false` Compose only warns you when the dependency service isn't started or available. If not defined
+    the default value of `required` is `true`.
 
 Service dependencies cause the following behaviors:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce a `required` attribut to `depends_on` to allow a Compose implementation to only warn user when a dependency service isn't started or available.

Why this change? 
Since the beginning the reference implementation Docker Compose was silently ignore missing dependency services, recently a fix was introduced to strictly follow the specification and broke existing users Compose configurations. 
Adding this new attribute will let them continue to use the previous behaviour while making clear and explicit the `depends_on` could be bypass by the Compose implementation

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #274 


