### PR TITLE
Add `start_interval` to healthcheck

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -896,9 +896,10 @@ healthcheck:
   timeout: 10s
   retries: 3
   start_period: 40s
+  start_interval: 5s
 ```
 
-`interval`, `timeout` and `start_period` are [specified as durations](11-extension.md#specifying-durations).
+`interval`, `timeout`, `start_period`, and `start_interval` are [specified as durations](11-extension.md#specifying-durations).
 
 `test` defines the command Compose will run to check container health. It can be
 either a string or a list. If it's a list, the first item must be either `NONE`, `CMD` or `CMD-SHELL`.

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -457,7 +457,8 @@
           ]
         },
         "timeout": {"type": "string", "format": "duration"},
-        "start_period": {"type": "string", "format": "duration"}
+        "start_period": {"type": "string", "format": "duration"},
+        "start_interval": {"type": "string", "format": "duration"}
       },
       "additionalProperties": false,
       "patternProperties": {"^x-": {}}

--- a/spec.md
+++ b/spec.md
@@ -1107,9 +1107,10 @@ healthcheck:
   timeout: 10s
   retries: 3
   start_period: 40s
+  start_interval: 5s
 ```
 
-`interval`, `timeout` and `start_period` are [specified as durations](11-extension.md#specifying-durations).
+`interval`, `timeout`, `start_period`, and `start_interval` are [specified as durations](11-extension.md#specifying-durations).
 
 `test` defines the command Compose will run to check container health. It can be
 either a string or a list. If it's a list, the first item must be either `NONE`, `CMD` or `CMD-SHELL`.


### PR DESCRIPTION
**What this PR does / why we need it**:

Start interval is the interval that healthchecks are performed during the start period.
This was added in moby in https://github.com/moby/moby/pull/40894.
You can see the linked issue in that PR for the number of users asking for this.

Docker CLI changes: https://github.com/docker/cli/pull/4405
Swarmkit changes: https://github.com/moby/swarmkit/pull/3142


