### PR TITLE
introduce depends_on.service to define the target service

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -380,6 +380,7 @@ expressed in the short form.
     to successful completion before starting a dependent service.
 - `required`: When set to `false` Compose only warns you when the dependency service isn't started or available. If it's not defined
     the default value of `required` is `true`.
+- `service`: name of the target service (defaults to mapping key). Value can be set by a variable.
 
 Service dependencies cause the following behaviors:
 
@@ -398,7 +399,8 @@ services:
   web:
     build: .
     depends_on:
-      db:
+      database:
+        service: db
         condition: service_healthy
         restart: true
       redis:

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -190,6 +190,7 @@
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
+                    "service": {"type": "string"},
                     "restart": {"type": "boolean"},
                     "required": {
                       "type":  "boolean",

--- a/spec.md
+++ b/spec.md
@@ -591,6 +591,7 @@ expressed in the short form.
     to successful completion before starting a dependent service.
 - `required`: When set to `false` Compose only warns you when the dependency service isn't started or available. If it's not defined
     the default value of `required` is `true`.
+- `service`: name of the target service (defaults to mapping key). Value can be set by a variable.
 
 Service dependencies cause the following behaviors:
 
@@ -609,7 +610,8 @@ services:
   web:
     build: .
     depends_on:
-      db:
+      database:
+        service: db
         condition: service_healthy
         restart: true
       redis:


### PR DESCRIPTION
**What this PR does / why we need it**:
introduce `depends_on.service` to define target service. Defaults to mapping key, but could be overridden, typically using a variable.

**Which issue(s) this PR fixes**:
see https://github.com/docker/compose/issues/10855

