### PR TITLE
docs: fix typo in `05-services.md` & `spec.md`

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -29,7 +29,7 @@ The default service configuration is `attach: true`.
 
 ### build
 
-`build` specifies the build configuration for creating a container image from source, as defined in the [Compsoe Build Specification](build.md).
+`build` specifies the build configuration for creating a container image from source, as defined in the [Compose Build Specification](build.md).
 
 ### blkio_config
 

--- a/spec.md
+++ b/spec.md
@@ -240,7 +240,7 @@ The default service configuration is `attach: true`.
 
 ### build
 
-`build` specifies the build configuration for creating a container image from source, as defined in the [Compsoe Build Specification](build.md).
+`build` specifies the build configuration for creating a container image from source, as defined in the [Compose Build Specification](build.md).
 
 ### blkio_config
 


### PR DESCRIPTION
**What this PR does / why we need it**:

fix typo in `05-services.md` & `spec.md`

**Which issue(s) this PR fixes**:

Fixes #405
Fixes #407