### PR TITLE
toc fix

### DIFF
--- a/build.md
+++ b/build.md
@@ -1,8 +1,4 @@
 # Compose Build Specification
-{:.no_toc}
-
-* ToC
-{:toc}
 
 > **Note:** 
 >

--- a/deploy.md
+++ b/deploy.md
@@ -1,8 +1,4 @@
 # Compose Deploy Specification
-{:.no_toc}
-
-* ToC
-{:toc}
 
 > **Note:** 
 >


### PR DESCRIPTION
Since the docs team has migrated from Jekyll to Hugo, we're now not able to set at what point in a .md file should be pulled into docs from an upstream repo. Consequently, we're seeing this:



![Screenshot 2023-08-23 at 13 09 56](https://github.com/compose-spec/compose-spec/assets/102604716/5ea614f4-dcef-40db-8568-2b8b1ca19c60)


This PR removes the toc markup (that I'm not sure was doing much anyway)