### PR TITLE
docs: update examples to use "example" namespace

### DIFF
--- a/02-model.md
+++ b/02-model.md
@@ -82,7 +82,7 @@ The example application is composed of the following parts:
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     ports:
       - "443:8043"
     networks:
@@ -94,7 +94,7 @@ services:
       - server-certificate
 
   backend:
-    image: awesome/database
+    image: example/database
     volumes:
       - db-data:/etc/data
     networks:

--- a/05-services.md
+++ b/05-services.md
@@ -1138,18 +1138,18 @@ is able to reach same `backend` service at `backend` or `mysql` on the `admin` n
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     networks:
       - front-tier
       - back-tier
 
   monitoring:
-    image: awesome/monitoring
+    image: example/monitoring
     networks:
       - admin
 
   backend:
-    image: awesome/backend
+    image: example/backend
     networks:
       back-tier:
         aliases:
@@ -1174,7 +1174,7 @@ The corresponding network configuration in the [top-level networks section](06-n
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     networks:
       front-tier:
         ipv4_address: 172.16.238.10
@@ -1492,7 +1492,7 @@ to the contents of the file `./server.cert`.
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     secrets:
       - server-certificate
 secrets:
@@ -1525,7 +1525,7 @@ the secret's lifecycle is not directly managed by Compose.
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     secrets:
       - source: server-certificate
         target: server.cert
@@ -1667,7 +1667,7 @@ and a bind mount defined for a single service.
 ```yml
 services:
   backend:
-    image: awesome/backend
+    image: example/backend
     volumes:
       - type: volume
         source: db-data

--- a/06-networks.md
+++ b/06-networks.md
@@ -14,7 +14,7 @@ is connected to `front-tier` and `back-tier` networks.
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     networks:
       - front-tier
       - back-tier
@@ -151,12 +151,12 @@ queries the platform for an existing network simply called `outside` and connect
 
 services:
   proxy:
-    image: awesome/proxy
+    image: example/proxy
     networks:
       - outside
       - default
   app:
-    image: awesome/app
+    image: example/app
     networks:
       - default
 

--- a/07-volumes.md
+++ b/07-volumes.md
@@ -12,7 +12,7 @@ The following example shows a two-service setup where a database's data director
 ```yml
 services:
   backend:
-    image: awesome/database
+    image: example/database
     volumes:
       - db-data:/etc/data
 
@@ -71,7 +71,7 @@ called `db-data` and mounts it into the `backend` service's containers.
 ```yml
 services:
   backend:
-    image: awesome/database
+    image: example/database
     volumes:
       - db-data:/etc/data
 

--- a/10-fragments.md
+++ b/10-fragments.md
@@ -47,7 +47,7 @@ to avoid repetition but overrides `name` attribute:
 
 services:
   backend:
-    image: awesome/database
+    image: example/database
     volumes:
       - db-data
       - metrics

--- a/11-extension.md
+++ b/11-extension.md
@@ -18,7 +18,7 @@ x-custom:
 
 services:
   webapp:
-    image: awesome/webapp
+    image: example/webapp
     x-foo: bar
 ```
 
@@ -99,7 +99,7 @@ x-keys: &keys
   KEY: VALUE
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     environment: 
       << : [*default-environment, *keys]
       YET_ANOTHER: VARIABLE

--- a/build.md
+++ b/build.md
@@ -45,11 +45,11 @@ The following example illustrates Compose Build Specification concepts with a co
 ```yaml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     build: ./webapp
 
   backend:
-    image: awesome/database
+    image: example/database
     build:
       context: backend
       dockerfile: ../backend.Dockerfile
@@ -60,11 +60,11 @@ services:
 
 When used to build service images from source, the Compose file creates three Docker images:
 
-* `awesome/webapp`: A Docker image is built using `webapp` sub-directory, within the Compose file's parent folder, as the Docker build context. Lack of a `Dockerfile` within this folder throws an error.
-* `awesome/database`: A Docker image is built using `backend` sub-directory within the Compose file parent folder. `backend.Dockerfile` file is used to define build steps, this file is searched relative to the context path, which means `..` resolves to the Compose file parent folder, so `backend.Dockerfile` is a sibling file.
+* `example/webapp`: A Docker image is built using `webapp` sub-directory, within the Compose file's parent folder, as the Docker build context. Lack of a `Dockerfile` within this folder throws an error.
+* `example/database`: A Docker image is built using `backend` sub-directory within the Compose file parent folder. `backend.Dockerfile` file is used to define build steps, this file is searched relative to the context path, which means `..` resolves to the Compose file parent folder, so `backend.Dockerfile` is a sibling file.
 * A Docker image is built using the `custom` directory with the user's HOME as the Docker context. Compose displays a warning about the non-portable path used to build image.
 
-On push, both `awesome/webapp` and `awesome/database` Docker images are pushed to the default registry. The `custom` service image is skipped as no `image` attribute is set and Compose displays a warning about this missing attribute.
+On push, both `example/webapp` and `example/database` Docker images are pushed to the default registry. The `custom` service image is skipped as no `image` attribute is set and Compose displays a warning about this missing attribute.
 
 ## Attributes
 

--- a/deploy.md
+++ b/deploy.md
@@ -24,7 +24,7 @@ are platform specific but the Compose Deploy Specification defines two canonical
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     ports:
       - "8080:80"
     deploy:
@@ -41,7 +41,7 @@ This assumes the platform has some native concept of "service" that can match th
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     deploy:
       labels:
         com.example.description: "This label will appear on the web service"
@@ -54,7 +54,7 @@ services:
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     deploy:
       mode: global
 ```
@@ -109,7 +109,7 @@ running at any given time.
 ```yml
 services:
   fronted:
-    image: awesome/webapp
+    image: example/webapp
     deploy:
       mode: replicated
       replicas: 6
@@ -126,7 +126,7 @@ as:
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     deploy:
       resources:
         limits:

--- a/spec.md
+++ b/spec.md
@@ -116,7 +116,7 @@ The example application is composed of the following parts:
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     ports:
       - "443:8043"
     networks:
@@ -128,7 +128,7 @@ services:
       - server-certificate
 
   backend:
-    image: awesome/database
+    image: example/database
     volumes:
       - db-data:/etc/data
     networks:
@@ -1349,18 +1349,18 @@ is able to reach same `backend` service at `backend` or `mysql` on the `admin` n
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     networks:
       - front-tier
       - back-tier
 
   monitoring:
-    image: awesome/monitoring
+    image: example/monitoring
     networks:
       - admin
 
   backend:
-    image: awesome/backend
+    image: example/backend
     networks:
       back-tier:
         aliases:
@@ -1385,7 +1385,7 @@ The corresponding network configuration in the [top-level networks section](06-n
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     networks:
       front-tier:
         ipv4_address: 172.16.238.10
@@ -1703,7 +1703,7 @@ to the contents of the file `./server.cert`.
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     secrets:
       - server-certificate
 secrets:
@@ -1736,7 +1736,7 @@ the secret's lifecycle is not directly managed by Compose.
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     secrets:
       - source: server-certificate
         target: server.cert
@@ -1878,7 +1878,7 @@ and a bind mount defined for a single service.
 ```yml
 services:
   backend:
-    image: awesome/backend
+    image: example/backend
     volumes:
       - type: volume
         source: db-data
@@ -1975,7 +1975,7 @@ is connected to `front-tier` and `back-tier` networks.
 ```yml
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     networks:
       - front-tier
       - back-tier
@@ -2112,12 +2112,12 @@ queries the platform for an existing network simply called `outside` and connect
 
 services:
   proxy:
-    image: awesome/proxy
+    image: example/proxy
     networks:
       - outside
       - default
   app:
-    image: awesome/app
+    image: example/app
     networks:
       - default
 
@@ -2222,7 +2222,7 @@ The following example shows a two-service setup where a database's data director
 ```yml
 services:
   backend:
-    image: awesome/database
+    image: example/database
     volumes:
       - db-data:/etc/data
 
@@ -2281,7 +2281,7 @@ called `db-data` and mounts it into the `backend` service's containers.
 ```yml
 services:
   backend:
-    image: awesome/database
+    image: example/database
     volumes:
       - db-data:/etc/data
 
@@ -2519,7 +2519,7 @@ to avoid repetition but overrides `name` attribute:
 
 services:
   backend:
-    image: awesome/database
+    image: example/database
     volumes:
       - db-data
       - metrics
@@ -2575,7 +2575,7 @@ x-custom:
 
 services:
   webapp:
-    image: awesome/webapp
+    image: example/webapp
     x-foo: bar
 ```
 
@@ -2656,7 +2656,7 @@ x-keys: &keys
   KEY: VALUE
 services:
   frontend:
-    image: awesome/webapp
+    image: example/webapp
     environment: 
       << : [*default-environment, *keys]
       YET_ANOTHER: VARIABLE


### PR DESCRIPTION
Switch to the "example" namespace on Docker Hub, which was reserved by Docker for this purpoose.


Although, I'd have to check-in with @kizbitz and @yosifkit to have the account/namespace labeled as "official" (or something) (and probably description to be changed) 😅 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #


