### PR TITLE
add a 'restart' action to watch attribute in the develop section

### DIFF
--- a/develop.md
+++ b/develop.md
@@ -51,7 +51,8 @@ Compose to monitor source code for changes. For more information, see [Use Compo
 `action` defines the action to take when changes are detected. If `action` is set to:
 
 - `rebuild`, Compose rebuilds the service image based on the `build` section and recreates the service with the updated image.
-- `sync`, Compose keeps the existing service container(s) running, but synchronizes source files with container content according to the `target` attribute. 
+- `sync`, Compose keeps the existing service container(s) running, but synchronizes source files with container content according to the `target` attribute.
+- `sync+restart`, Compose synchronizes source files with container content according to the `target` attribute, and then restarts the container.
 
 
 #### ignore

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -475,7 +475,7 @@
             "properties": {
               "ignore": {"type": "array", "items": {"type": "string"}},
               "path": {"type": "string"},
-              "action": {"type": "string", "enum": ["rebuild", "sync"]},
+              "action": {"type": "string", "enum": ["rebuild", "sync", "sync+restart"]},
               "target": {"type": "string"}
             }
           },


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new action `restart` to the `watch` attribute of the develop section. 
This action will first sync files and the restart the container.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes https://github.com/docker/compose/issues/11062


