### PR TITLE
un-deprecate scale

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -1495,9 +1495,8 @@ web:
 
 ## scale
 
-_DEPRECATED: use [deploy/replicas](deploy.md#replicas)_
-
 `scale` specifies the default number of containers to deploy for this service.
+When both are set, `scale` must be consistent with the `replicas` attribute in the [Deploy Specification](deploy.md#replicas).
 
 ## secrets
 

--- a/spec.md
+++ b/spec.md
@@ -1708,9 +1708,8 @@ web:
 
 ## scale
 
-_DEPRECATED: use [deploy/replicas](deploy.md#replicas)_
-
 `scale` specifies the default number of containers to deploy for this service.
+When both are set, `scale` must be consistent with the `replicas` attribute in the [Deploy Specification](deploy.md#replicas).
 
 ## secrets
 


### PR DESCRIPTION
This resurrect `scale` as a legitimate attribute to be set, as a simpler way to define replicas vs `deploy` section

