### PR TITLE
path and action are required to register a watcher

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -461,6 +461,7 @@
               "target": {"type": "string"}
             }
           },
+          "required": ["path", "action"],
           "additionalProperties": false,
           "patternProperties": {"^x-": {}}
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
make `path` and `action` required attributes to define a watcher.
Follow-up PR on compose-go should also check path is not empty

**Which issue(s) this PR fixes**:
See https://github.com/docker/compose/issues/11182


