### PR TITLE
fix - fixes definition/development properties

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -459,11 +459,11 @@
               "path": {"type": "string"},
               "action": {"type": "string", "enum": ["rebuild", "sync", "sync+restart"]},
               "target": {"type": "string"}
-            }
-          },
-          "required": ["path", "action"],
-          "additionalProperties": false,
-          "patternProperties": {"^x-": {}}
+            },
+            "required": ["path", "action"],
+            "additionalProperties": false,
+            "patternProperties": {"^x-": {}}
+          }
         }
       }
     },


### PR DESCRIPTION

**Fixes definition/development properties**:

Several properties for watch were left outside of `items`, which was causing errors when trying to import the spec to cue.

I was trying to import the spec into cue using the folowing commands:

```
curl -sL https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json > compose-spec.json && \
cue import -f --outfile - -l '#ComposeSpec:' --package 'compose' compose-spec.json   
```

Which caused the following error:
```
constraint not allowed because type object is excluded:
    ./compose-spec.json:464:11
```
Moving the orphaned attributes into "items" fixed the issue for me.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #


