### PR TITLE
Fix an error in `dns_search` description

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -471,7 +471,7 @@ dns_opt:
 
 ### dns_search
 
-`dns` defines custom DNS search domains to set on container network interface configuration. It can be a single value or a list.
+`dns_search` defines custom DNS search domains to set on container network interface configuration. It can be a single value or a list.
 
 ```yml
 dns_search: example.com


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an error in the section describing [the `dns_search` configuration](https://github.com/compose-spec/compose-spec/blob/b0e5a16eaf4438ec9e8a8f25ee8fc0074c3d790c/05-services.md?plain=1#L472-L474). The current description erroneously refers to `dns` instead of `dns_search`.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
N/A


