### PR TITLE
add new mac_address attribute to service.networks definition

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -294,6 +294,7 @@
                         "ipv4_address": {"type": "string"},
                         "ipv6_address": {"type": "string"},
                         "link_local_ips": {"$ref": "#/definitions/list_of_strings"},
+                        "mac_address": {"type": "string"},
                         "priority": {"type": "number"}
                       },
                       "additionalProperties": false,


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the missing change from #435 to `compose-spec.json` file

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->


