### PR TITLE
Permit '=' separator and '[ipv6]' in 'extra_hosts'

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -850,12 +850,28 @@ external_links:
 `extra_hosts` adds hostname mappings to the container network interface configuration (`/etc/hosts` for Linux).
 
 ### Short syntax
-Short syntax uses plain strings in a list. Values must set hostname and IP address for additional hosts in the form of `HOSTNAME:IP`.
+Short syntax uses plain strings in a list. Values must set hostname and IP address for additional hosts in the form of `HOSTNAME=IP`.
+
+```yml
+extra_hosts:
+  - "somehost=162.242.195.82"
+  - "otherhost=50.31.209.229"
+  - "myhostv6=::1"
+```
+
+IPv6 addresses can be enclosed in square brackets, for example:
+
+```yml
+extra_hosts:
+  - "myhostv6=[::1]"
+```
+
+The separator `=` is preferred, but `:` can also be used. For example:
 
 ```yml
 extra_hosts:
   - "somehost:162.242.195.82"
-  - "otherhost:50.31.209.229"
+  - "myhostv6:::1"
 ```
 
 ### Long syntax
@@ -865,6 +881,7 @@ Alternatively, `extra_hosts` can be set as a mapping between hostname(s) and IP(
 extra_hosts:
   somehost: "162.242.195.82"
   otherhost: "50.31.209.229"
+  myhostv6: "::1"
 ```
 
 Compose creates a matching entry with the IP address and hostname in the container's network
@@ -873,6 +890,7 @@ configuration, which means for Linux `/etc/hosts` get extra lines:
 ```
 162.242.195.82  somehost
 50.31.209.229   otherhost
+::1             myhostv6
 ```
 
 ## group_add

--- a/build.md
+++ b/build.md
@@ -291,8 +291,23 @@ Illustrative examples of how this is used in Buildx can be found
 
 ```yml
 extra_hosts:
+  - "somehost=162.242.195.82"
+  - "otherhost=50.31.209.229"
+  - "myhostv6=::1"
+```
+IPv6 addresses can be enclosed in square brackets, for example:
+
+```yml
+extra_hosts:
+  - "myhostv6=[::1]"
+```
+
+The separator `=` is preferred, but `:` can also be used. For example:
+
+```yml
+extra_hosts:
   - "somehost:162.242.195.82"
-  - "otherhost:50.31.209.229"
+  - "myhostv6:::1"
 ```
 
 Compose creates matching entry with the IP address and hostname in the container's network
@@ -301,6 +316,7 @@ configuration, which means for Linux `/etc/hosts` will get extra lines:
 ```
 162.242.195.82  somehost
 50.31.209.229   otherhost
+::1             myhostv6
 ```
 
 ### isolation

--- a/spec.md
+++ b/spec.md
@@ -1063,12 +1063,28 @@ external_links:
 `extra_hosts` adds hostname mappings to the container network interface configuration (`/etc/hosts` for Linux).
 
 ### Short syntax
-Short syntax uses plain strings in a list. Values must set hostname and IP address for additional hosts in the form of `HOSTNAME:IP`.
+Short syntax uses plain strings in a list. Values must set hostname and IP address for additional hosts in the form of `HOSTNAME=IP`.
+
+```yml
+extra_hosts:
+  - "somehost=162.242.195.82"
+  - "otherhost=50.31.209.229"
+  - "myhostv6=::1"
+```
+
+IPv6 addresses can be enclosed in square brackets, for example:
+
+```yml
+extra_hosts:
+  - "myhostv6=[::1]"
+```
+
+The separator `=` is preferred, but `:` can also be used. For example:
 
 ```yml
 extra_hosts:
   - "somehost:162.242.195.82"
-  - "otherhost:50.31.209.229"
+  - "myhostv6:::1"
 ```
 
 ### Long syntax
@@ -1078,6 +1094,7 @@ Alternatively, `extra_hosts` can be set as a mapping between hostname(s) and IP(
 extra_hosts:
   somehost: "162.242.195.82"
   otherhost: "50.31.209.229"
+  myhostv6: "::1"
 ```
 
 Compose creates a matching entry with the IP address and hostname in the container's network
@@ -1086,6 +1103,7 @@ configuration, which means for Linux `/etc/hosts` get extra lines:
 ```
 162.242.195.82  somehost
 50.31.209.229   otherhost
+::1             myhostv6
 ```
 
 ## group_add


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the `extra_hosts` element to align with changes in 'docker/cli' and 'docker/buildx' that make it easier to specify IPv6 addresses in the `--add-host` option (by permitting `host=ip` in addition to `host:ip`, and allowing square brackets around the address).

For example:

```
extra_hosts:
    - "somehost=162.242.195.82"
    - "myhostv6=::1"
    - "anotherhostv6=[2001:4860:4860::8888]"
```

_My intention is to allow brackets around an address in the long/mapping form of `extra_hosts` as well, because it's unambiguous and consistent with the short form - but it's a slightly unusual thing to do, because the brackets are only normally used in a URI or when there's a port number - so, haven't added an example to the docs. But, to note it here, it'll look like ..._

```
extra_hosts:
    myhostv6: "[::1]"
```

**Which issue(s) this PR fixes**:

Fixes docker/cli#4648