### PR TITLE
docs: `08-configs.md` - Add min version for `content` property

### DIFF
--- a/08-configs.md
+++ b/08-configs.md
@@ -14,7 +14,7 @@ The top-level `configs` declaration defines or references configuration data tha
 
 - `file`: The config is created with the contents of the file at the specified path.
 - `environment`: The config content is created with the value of an environment variable.
-- `content`: The content is created with the inlined value.
+- `content`: The content is created with the inlined value. (_Available since Docker Compose v2.23.1_)
 - `external`: If set to true, `external` specifies that this config has already been created. Compose does not
   attempt to create it, and if it does not exist, an error occurs.
 - `name`: The name of the config object in the container engine to look up. This field can be used to
@@ -42,10 +42,9 @@ configs:
 
 ## Example 2
 
-`<project_name>_app_config` is created when the application is deployed,
-by registering the inlined content as the configuration data. This comes with the
-benefits Compose will infer variables when creating the config, which allows to
-adjust content according to service configuration:
+`<project_name>_app_config` is created when the application is deployed, by registering the inlined content as the configuration data.
+
+This comes with the benefits Compose will [infer variables][interpolation] when creating the config, which allows to adjust content according to service configuration:
 
 ```yml
 configs:
@@ -62,7 +61,7 @@ External configs lookup can also use a distinct key by specifying a `name`.
 
 The following
 example modifies the previous one to look up a config using the parameter `HTTP_CONFIG_KEY`. The
-the actual lookup key will is set at deployment time by the [interpolation](12-interpolation.md) of
+the actual lookup key will is set at deployment time by the [interpolation] of
 variables, but exposed to containers as hard-coded ID `http_config`.
 
 ```yml
@@ -73,3 +72,5 @@ configs:
 ```
 
 If `external` is set to `true`, all other attributes apart from `name` are irrelevant. If Compose detecs any other attribute, it rejects the Compose file as invalid.
+
+[interpolation]: 12-interpolation.md


### PR DESCRIPTION
## What this PR does / why we need it:

Presently [this feature is documented](https://docs.docker.com/compose/compose-file/08-configs/#example-2), but it is not obvious that the feature is very new (_mid Nov 2023, nor presently available in Docker Desktop releases since then_).

The release notes for Docker Compose don't mention it, so it was a bit of an effort to [track this information down](https://github.com/compose-spec/compose-spec/pull/429#issuecomment-1828925468).


#### Validation UX (_cite min version in docs_)

It is better to clarify this requirement in the docs, as the experience on a slightly older compose had the following output:

```
$ docker compose config

WARN[0000] The "yfl9g2QkiNfde8Xs" variable is not set. Defaulting to a blank string.
WARN[0000] The "HwD7ncFvC" variable is not set. Defaulting to a blank string.
validating /path/to/compose.yaml: configs.dms_accounts Additional property content is not allowed
```

That is confusing initially, especially after ensuring software is updated. It becomes unclear if it's a bug or what the supported version is, or if it were user/documentation error.

#### Warning UX (_link to interpolation docs_)

**`compose.yaml`:**

```yml
services:
  dms:
    configs:
      - source: dms_accounts
        target: /tmp/docker-mailserver/postfix-accounts.cf
        mode: 0640

# Useful for tests when the source should be read-only but the container copy RW
# While a RW volume mount persists changes, this config is created new each time.
# https://github.com/compose-spec/compose-spec/issues/346#issuecomment-1841606534
configs:
  # Login credentials (user: "admin@example.test" password: "secret")
  dms_accounts:
    content: |
      admin@example.test|{SHA512-CRYPT}$6$yfl9g2QkiNfde8Xs$HwD7ncFvC/kVbuHjRYWJG.UJWTYUExR1C8pNoESE1pqP8lFVRlusseb82kuNOogE1jSpTNBMZK/mLZZAcMPSU0
```

Due to the above experience, I included the [interpolation docs page](https://docs.docker.com/compose/compose-file/12-interpolation/) link in this example description as well, to better raise awareness of `$` being accidentally treated as a variable.

Although the escape syntax tip could do with better visibility from the noise on that page too (_let me know if I should correct that in this PR as well_):

<details>
<summary>Screenshot (click to expand)</summary>

![image](https://github.com/compose-spec/compose-spec/assets/5098581/95e63430-a151-417c-8244-e4f0b43321bc)

</details>

A section header could better split the concerns of supported syntax for the interpolation feature and the troubleshooting syntax `$$` for opt-out.

## Which issue(s) this PR fixes

I can make one otherwise this description is the issue to fix. (_**EDIT:** Opened an [issue downstream at `docker/docs`](https://github.com/docker/docs/issues/18809)_)

Technically the concerns are about `docker/docs` and Docker Compose, but those pages are imported from this repo.

