### PR TITLE
Add workflow to sync compose-spec.json file from compose-go repository

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,29 @@
+name: Sync compose-spec json
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  schema:
+    name: Update Schema
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download schema
+        run: curl -fSL -o schema/compose-spec.json https://raw.githubusercontent.com/compose-spec/compose-go/main/schema/compose-spec.json
+
+      - name: Show diff
+        run: git diff schema/compose-spec.json
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: Update compose-spec.json
+          commit-message: Update compose-spec.json
+          signoff: true
+          branch: compose-spec-json


### PR DESCRIPTION
**What this PR does / why we need it**:
As the code parsing and managing the `compose-spec.json` file is located in the `compose-go` repository, it makes more sense use it as a the reference and sync the `schema/compose-spec.json` from this source.




