### PR TITLE
Fix schema for top-level include key

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -20,7 +20,6 @@
     "include": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/include"
       },
       "description": "compose sub-projects to be included."


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes schema for top level `include` key.

Without the fix, the following snippet won't pass schema check, despite it is give in the public doc: [link](https://github.com/compose-spec/compose-spec/blob/master/14-include.md)

```
include:
  - my-compose-include.yaml  #with serviceB declared
```

**Which issue(s) this PR fixes**:

There's no open issue for this fix.
