### PR TITLE
fix confusion between networks and network_mode

### DIFF
--- a/06-networks.md
+++ b/06-networks.md
@@ -66,46 +66,10 @@ driver is not available on the platform.
 ```yml
 networks:
   db-data:
-    driver: overlay
+    driver: bridge
 ```
 
-Default and available values are platform specific. Compose supports the following drivers:
-`none` and `host`
-
-- `host`: Use the host's networking stack.
-- `none`: Turn off networking.
-
-#### host or none
-
-The syntax for using built-in networks such as `host` and `none` is different, as such networks implicitly exist outside
-the scope of Compose. To use them, you must define an external network with the name `host` or `none` and
-an alias that Compose can use (`hostnet` and `nonet` in the following example), then grant the service
-access to that network using its alias.
-
-```yml
-services:
-  web:
-    networks:
-      hostnet: {}
-
-networks:
-  hostnet:
-    external: true
-    name: host
-```
-
-```yml
-services:
-  web:
-    ...
-    networks:
-      nonet: {}
-
-networks:
-  nonet:
-    external: true
-    name: none
-```
+Default and available values are platform specific.
 
 ### driver_opts
 

--- a/spec.md
+++ b/spec.md
@@ -2075,46 +2075,10 @@ driver is not available on the platform.
 ```yml
 networks:
   db-data:
-    driver: overlay
+    driver: bridge
 ```
 
-Default and available values are platform specific. Compose supports the following drivers:
-`none` and `host`
-
-- `host`: Use the host's networking stack.
-- `none`: Turn off networking.
-
-#### host or none
-
-The syntax for using built-in networks such as `host` and `none` is different, as such networks implicitly exist outside
-the scope of Compose. To use them, you must define an external network with the name `host` or `none` and
-an alias that Compose can use (`hostnet` and `nonet` in the following example), then grant the service
-access to that network using its alias.
-
-```yml
-services:
-  web:
-    networks:
-      hostnet: {}
-
-networks:
-  hostnet:
-    external: true
-    name: host
-```
-
-```yml
-services:
-  web:
-    ...
-    networks:
-      nonet: {}
-
-networks:
-  nonet:
-    external: true
-    name: none
-```
+Default and available values are platform specific.
 
 ### driver_opts
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`networks` section has description for "host or none" which actually applies to network_mode in services, not network top level element.


