### PR TITLE
introduce port.name

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -1416,18 +1416,21 @@ expressed in the short form.
 - `host_ip`: The Host IP mapping, unspecified means all network interfaces (`0.0.0.0`).
 - `protocol`: The port protocol (`tcp` or `udp`). Defaults to `tcp`.
 - `mode`: `host`: For publishing a host port on each node, or `ingress` for a port to be load balanced. Defaults to `ingress`.
+- `name`: A human-readable name for the port, used to document it's usage within the service
 
 ```yml
 ports:
-  - target: 80
+  - name: http
+    target: 80
     host_ip: 127.0.0.1
     published: "8080"
     protocol: tcp
-    mode: host
+    mode: host    
 
-  - target: 80
+  - name: https
+    target: 443
     host_ip: 127.0.0.1
-    published: "8000-9000"
+    published: "8083-9000"
     protocol: tcp
     mode: host
 ```

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -322,6 +322,7 @@
               {
                 "type": "object",
                 "properties": {
+                  "name": {"type": "string"},
                   "mode": {"type": "string"},
                   "host_ip": {"type": "string"},
                   "target": {"type": "integer"},

--- a/spec.md
+++ b/spec.md
@@ -1629,18 +1629,21 @@ expressed in the short form.
 - `host_ip`: The Host IP mapping, unspecified means all network interfaces (`0.0.0.0`).
 - `protocol`: The port protocol (`tcp` or `udp`). Defaults to `tcp`.
 - `mode`: `host`: For publishing a host port on each node, or `ingress` for a port to be load balanced. Defaults to `ingress`.
+- `name`: A human-readable name for the port, used to document it's usage within the service
 
 ```yml
 ports:
-  - target: 80
+  - name: http
+    target: 80
     host_ip: 127.0.0.1
     published: "8080"
     protocol: tcp
-    mode: host
+    mode: host    
 
-  - target: 80
+  - name: https
+    target: 443
     host_ip: 127.0.0.1
-    published: "8000-9000"
+    published: "8083-9000"
     protocol: tcp
     mode: host
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
introduce port.name to document role of a port within a service

see https://github.com/compose-spec/compose-go/pull/566