### PR TITLE
remove restriction for `extends` to refer to another resource

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -660,15 +660,15 @@ extends:
 
 ### Restrictions
 
-The following restrictions apply to the service being referenced:
+Service being referenced by `extends` can have dependency declared on other resources. Typically it can have an explicit `volumes` declaration.
+`extends` then will not import the target volume definition in the extending compose model, it is Compose file author responsibility to define
+an equivalent resource for the extended service to be consistent. Compose will check a resource with referenced ID exists in the Compose model
 
-- Services that have dependencies on other services cannot be used as a base. Therefore, any key
-  that introduces a dependency on another service is incompatible with `extends`. The
-  non-exhaustive list of such keys is: `links`, `volumes_from`, `container` mode (in `ipc`, `pid`,
-  `network_mode` and `net`), `service` mode (in `ipc`, `pid` and `network_mode`), `depends_on`.
-- Services cannot have circular references with `extends`.
+Dependencies on other resources in an `extends` target can be:
+- An explicit references by `volumes`, `networks`, `configs`, `secrets`, `links`, `volumes_from` or `depends_on`
+- A reference to another service using the `service:{name}` syntax in namespace declaration (`ipc`, `pid`, `network_mode`)
 
-Compose returns an error in all of these cases.
+Circular references with `extends` are not supported, Compose returns an error when one is detected.
 
 ### Finding referenced service
 

--- a/spec.md
+++ b/spec.md
@@ -873,15 +873,15 @@ extends:
 
 ### Restrictions
 
-The following restrictions apply to the service being referenced:
+Service being referenced by `extends` can have dependency declared on other resources. Typically it can have an explicit `volumes` declaration.
+`extends` then will not import the target volume definition in the extending compose model, it is Compose file author responsibility to define
+an equivalent resource for the extended service to be consistent. Compose will check a resource with referenced ID exists in the Compose model
 
-- Services that have dependencies on other services cannot be used as a base. Therefore, any key
-  that introduces a dependency on another service is incompatible with `extends`. The
-  non-exhaustive list of such keys is: `links`, `volumes_from`, `container` mode (in `ipc`, `pid`,
-  `network_mode` and `net`), `service` mode (in `ipc`, `pid` and `network_mode`), `depends_on`.
-- Services cannot have circular references with `extends`.
+Dependencies on other resources in an `extends` target can be:
+- An explicit references by `volumes`, `networks`, `configs`, `secrets`, `links`, `volumes_from` or `depends_on`
+- A reference to another service using the `service:{name}` syntax in namespace declaration (`ipc`, `pid`, `network_mode`)
 
-Compose returns an error in all of these cases.
+Circular references with `extends` are not supported, Compose returns an error when one is detected.
 
 ### Finding referenced service
 


### PR DESCRIPTION
**What this PR does / why we need it**:
for legacy reasons, `extends` was documented to forbid any reference to another service. Same consistency issue applies to volumes/networks/.. without such a constraint to be applied, and consistency check during parsing allows to discover misconfigurations. This PR removes this requirement, while documenting the need for compose file author to check resources exists in the extending model

**Which issue(s) this PR fixes**:
see https://github.com/docker/compose/issues/11544

