### PR TITLE
un-deprecate cpus/mem_limit/pids_limit

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -130,10 +130,11 @@ an integer value using microseconds as unit or a [duration](11-extension.md#spec
 
 ## cpus
 
-_DEPRECATED: use [deploy.limits.cpus](deploy.md#cpus)_
-
 `cpus` define the number of (potentially virtual) CPUs to allocate to service containers. This is a fractional number.
 `0.000` means no limit.
+
+When both are set, `cpus` must be consistent with the `cpus` attribute in the
+[Deploy Specification](deploy.md#cpus)
 
 ## cpuset
 
@@ -1288,11 +1289,17 @@ networks:
 
 ## mem_limit
 
-_DEPRECATED: use [deploy.limits.memory](deploy.md#memory)_
+`mem_limit` configures a limit on the amount of memory a container can allocate, set as a string expressing a [byte value](11-extension.md#specifying-byte-values).
+
+
+When both are set, `mem_limit` must be consistent with the `limits.memory` attribute in the [Deploy Specification](deploy.md#memory)
+
 
 ## mem_reservation
 
-_DEPRECATED: use [deploy.reservations.memory](deploy.md#memory)_
+`mem_reservation` configures a reservation on the amount of memory a container can allocate, set as a string expressing a [byte value](11-extension.md#specifying-byte-values).
+
+When both are set, `mem_reservation` must be consistent with the `reservations.memory` attribute in the [Deploy Specification](deploy.md#memory)
 
 ## mem_swappiness
 
@@ -1334,13 +1341,13 @@ Supported values are platform specific.
 
 ## pids_limit
 
-_DEPRECATED: use [deploy.resources.limits.pids](deploy.md#pids)_
-
 `pids_limit` tunes a container’s PIDs limit. Set to -1 for unlimited PIDs.
 
 ```yml
 pids_limit: 10
 ```
+
+When both are set, `pids_limit` must be consistent with the `pids` attribute in the [Deploy Specification](deploy.md#pids)
 
 ## platform
 

--- a/spec.md
+++ b/spec.md
@@ -343,10 +343,11 @@ an integer value using microseconds as unit or a [duration](11-extension.md#spec
 
 ## cpus
 
-_DEPRECATED: use [deploy.limits.cpus](deploy.md#cpus)_
-
 `cpus` define the number of (potentially virtual) CPUs to allocate to service containers. This is a fractional number.
 `0.000` means no limit.
+
+When both are set, `cpus` must be consistent with the `cpus` attribute in the
+[Deploy Specification](deploy.md#cpus)
 
 ## cpuset
 
@@ -1501,11 +1502,17 @@ networks:
 
 ## mem_limit
 
-_DEPRECATED: use [deploy.limits.memory](deploy.md#memory)_
+`mem_limit` configures a limit on the amount of memory a container can allocate, set as a string expressing a [byte value](11-extension.md#specifying-byte-values).
+
+
+When both are set, `mem_limit` must be consistent with the `limits.memory` attribute in the [Deploy Specification](deploy.md#memory)
+
 
 ## mem_reservation
 
-_DEPRECATED: use [deploy.reservations.memory](deploy.md#memory)_
+`mem_reservation` configures a reservation on the amount of memory a container can allocate, set as a string expressing a [byte value](11-extension.md#specifying-byte-values).
+
+When both are set, `mem_reservation` must be consistent with the `reservations.memory` attribute in the [Deploy Specification](deploy.md#memory)
 
 ## mem_swappiness
 
@@ -1547,13 +1554,13 @@ Supported values are platform specific.
 
 ## pids_limit
 
-_DEPRECATED: use [deploy.resources.limits.pids](deploy.md#pids)_
-
 `pids_limit` tunes a container’s PIDs limit. Set to -1 for unlimited PIDs.
 
 ```yml
 pids_limit: 10
 ```
+
+When both are set, `pids_limit` must be consistent with the `pids` attribute in the [Deploy Specification](deploy.md#pids)
 
 ## platform
 


### PR DESCRIPTION
**What this PR does / why we need it**:

remove deprecation of resource limits and require values are consistent with `deploy` section

