### PR TITLE
Add missing "app_protocol" property

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -327,7 +327,8 @@
                   "host_ip": {"type": "string"},
                   "target": {"type": "integer"},
                   "published": {"type": ["string", "integer"]},
-                  "protocol": {"type": "string"}
+                  "protocol": {"type": "string"},
+                  "app_protocol": {"type": "string"}
                 },
                 "additionalProperties": false,
                 "patternProperties": {"^x-": {}}


### PR DESCRIPTION
**What this PR does / why we need it**:

This property can be found in the [documentation](https://docs.docker.com/compose/compose-file/05-services/#long-syntax-3) but not in this spec.

**Which issue(s) this PR fixes**:
Fixes #478


