### PR TITLE
Introduce `profiles` attribute for `depends_on` to define profiles dependency

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -388,6 +388,8 @@ expressed in the short form.
     to successful completion before starting a dependent service.
 - `required`: When set to `false` Compose only warns you when the dependency service isn't started or available. If it's not defined
     the default value of `required` is `true`. [![Compose v2.20.0](https://img.shields.io/badge/compose-v2.20.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.20.0)
+- `profiles`: Sets the profiles that will be activated when checking dependency services. Services in specified profiles are selected
+    for condition checking, and will be started when not running. Stop of compose project will not select these services.
 
 
 Service dependencies cause the following behaviors:

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -201,7 +201,8 @@
                     "condition": {
                       "type": "string",
                       "enum": ["service_started", "service_healthy", "service_completed_successfully"]
-                    }
+                    },
+                    "profiles": {"$ref": "#/definitions/list_of_strings"}
                   },
                   "required": ["condition"]
                 }

--- a/spec.md
+++ b/spec.md
@@ -601,6 +601,8 @@ expressed in the short form.
     to successful completion before starting a dependent service.
 - `required`: When set to `false` Compose only warns you when the dependency service isn't started or available. If it's not defined
     the default value of `required` is `true`. [![Compose v2.20.0](https://img.shields.io/badge/compose-v2.20.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.20.0)
+- `profiles`: Sets the profiles that will be activated when checking dependency services. Services in specified profiles are selected
+    for condition checking, and will be started when not running. Stop of compose project will not select these services.
 
 
 Service dependencies cause the following behaviors:


### PR DESCRIPTION
**What this PR does / why we need it**:

Before compose version `2.18.1`, starting a service depending on services in an inactivated profile will not trigger error. This behavior gets fixed in https://github.com/docker/compose/pull/10602.

However, the problem with this feature is that it's implicit, but not that it's of no value. In fact, before and after the fix landed many people report and request about this feature to be available. `required` keyword was added for it in https://github.com/compose-spec/compose-spec/pull/382.

This PR takes the solution further, to explicitly support specifying `profiles` as dependency in `depends_on` entries. 

Behavior of `depends_on.profiles`:
1. Services in specified profiles are selected for condition checking, and will be started when not running.
2. Stop of compose project will not select these services.

Example config:
```yml
services:
  db:
    profiles: [db]
    depends_on:
      - db-init

  db-init:
    profiles: [db]

  web:
    profiles: [web]
    depends_on:
      db:
        condition: service_healthy
        profiles: [db]
      web-redis:

  web-redis:
    profiles: [web]
```
`db` is central db for all services, `web-redis` is redis instance that only serves `web`.
Here:
* Run `docker compose --profile web up` when `db` not created/started:
   `db-init` and `db` will be created and started, then `web-redis` and `web` is created and started.
* Run `docker compose --profile web up --force-recreate` when `db` is healthy:
   Only `web-redis` and `web` is selected and created/started, **since `db` is already ready**.
* Run `docker compose --profile web down` when `db` is healthy:
   **`db` will not be selected**, only `web-redis` and `web` is stopped and removed.
* Run `docker compose --profile web restart` when `db` is healthy:
   **`db` will not be selected**, only `web-redis` and `web` is restarted.

More formal use cases of this feature will be elaborated on subsequent comments.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
https://github.com/docker/compose/issues/10751
https://github.com/docker/compose/issues/10804
https://github.com/compose-spec/compose-spec/issues/274
https://github.com/docker/compose/issues/10993