### PR TITLE
chore(spec.md): Remove YAML 1.1 concern for port syntax

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1620,9 +1620,6 @@ value or a range. Host and container must use equivalent ranges.
 Either specify both ports (`HOST:CONTAINER`), or just the container port. In the latter case,
 the container runtime automatically allocates any unassigned port of the host.
 
-`HOST:CONTAINER` should always be specified as a (quoted) string, to avoid conflicts
-with [yaml base-60 float](https://yaml.org/type/float.html).
-
 Examples:
 
 ```yml


### PR DESCRIPTION
## What this PR does / why we need it

YAML 1.2 (_published 2009Q3_) dropped this number format. Technically still a valid concern if the YAML parser is not 1.2 compliant (_third-party implementations?_).

I covered history and details in a related PR: https://github.com/docker-mailserver/docker-mailserver/pull/3982

## Which issue(s) this PR fixes

I just noticed that this was added to the spec in Jan 2020 with many other changes and no context available. This was an issue with the Python version of Docker Compose AFAIK, but is intentionally avoided with the YAML parser package used in the Go rewrite.

As far as quoting goes, that should only be relevant for ports 0-59 when the YAML parser is not YAML 1.2 compliant?

Feel free to reject 👍 (_if otherwise wanting to merge, let me know and I'll sort out that DCO check_)