### PR TITLE
Fix compose schema according to Draft7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
+        name: Test
+        run: |
+          make test-spec
+      -
         name: Run
         run: |
           make validate-spec

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 # syntax=docker/dockerfile:1
 
+FROM golang:1.22-alpine3.18 AS spec-test
+COPY /schema /schema
+COPY /tests /tests
+WORKDIR /tests
+RUN go mod download
+RUN go test ./compose-spec_test.go
+
 FROM node:16.1 as generator
 RUN npm install -g @adobe/jsonschema2md
 COPY schema /schema

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,9 @@ validate-spec: ## validate the spec.md does not change
 	@docker buildx build . \
 	-f ./Dockerfile \
 	--target spec-validate
+
+.PHONY: test-spec
+test-spec: ## Run tests against compose-spec.json schema
+	@docker buildx build . \
+	-f ./Dockerfile \
+	--target spec-test

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema#",
-  "id": "compose_spec.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "compose_spec.json",
   "type": "object",
   "title": "Compose Specification",
   "description": "The Compose file is a YAML file defining a multi-containers based application.",
@@ -20,14 +20,13 @@
     "include": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/include"
       },
       "description": "compose sub-projects to be included."
     },
 
     "services": {
-      "id": "#/properties/services",
+      "$id": "#/properties/services",
       "type": "object",
       "patternProperties": {
         "^[a-zA-Z0-9._-]+$": {
@@ -38,7 +37,7 @@
     },
 
     "networks": {
-      "id": "#/properties/networks",
+      "$id": "#/properties/networks",
       "type": "object",
       "patternProperties": {
         "^[a-zA-Z0-9._-]+$": {
@@ -48,7 +47,7 @@
     },
 
     "volumes": {
-      "id": "#/properties/volumes",
+      "$id": "#/properties/volumes",
       "type": "object",
       "patternProperties": {
         "^[a-zA-Z0-9._-]+$": {
@@ -59,7 +58,7 @@
     },
 
     "secrets": {
-      "id": "#/properties/secrets",
+      "$id": "#/properties/secrets",
       "type": "object",
       "patternProperties": {
         "^[a-zA-Z0-9._-]+$": {
@@ -70,7 +69,7 @@
     },
 
     "configs": {
-      "id": "#/properties/configs",
+      "$id": "#/properties/configs",
       "type": "object",
       "patternProperties": {
         "^[a-zA-Z0-9._-]+$": {
@@ -87,7 +86,7 @@
   "definitions": {
 
     "service": {
-      "id": "#/definitions/service",
+      "$id": "#/definitions/service",
       "type": "object",
 
       "properties": {
@@ -115,7 +114,7 @@
                 "network": {"type": "string"},
                 "pull": {"type": "boolean"},
                 "target": {"type": "string"},
-                "shm_size": {"type": ["integer", "string"]},
+                "shm_size": {"anyOf":[{"type":"integer"},{"type":"string"}]},
                 "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
                 "isolation": {"type": "string"},
                 "privileged": {"type": "boolean"},
@@ -165,12 +164,15 @@
         "container_name": {"type": "string"},
         "cpu_count": {"type": "integer", "minimum": 0},
         "cpu_percent": {"type": "integer", "minimum": 0, "maximum": 100},
-        "cpu_shares": {"type": ["number", "string"]},
-        "cpu_quota": {"type": ["number", "string"]},
-        "cpu_period": {"type": ["number", "string"]},
-        "cpu_rt_period": {"type": ["number", "string"]},
-        "cpu_rt_runtime": {"type": ["number", "string"]},
-        "cpus": {"type": ["number", "string"]},
+        "cpu_shares": {"anyOf":[{"type":"number"},{"type":"string"}]},
+        "cpu_quota": {"anyOf":[{"type":"number"},{"type":"string"}]},
+        "cpu_period": {"anyOf":[{"type":"number"},{"type":"string"}]},
+        "cpu_rt_period": {"anyOf":[{"type":"number"},{"type":"string"}]},
+        "cpu_rt_runtime": {"anyOf":[{"type":"number"},{"type":"string"}]},
+        "cpus": { "anyOf": [
+          {"type": "number"},
+          {"type": "string"}
+        ]},
         "cpuset": {"type": "string"},
         "credential_spec": {
           "type": "object",
@@ -222,8 +224,13 @@
         "expose": {
           "type": "array",
           "items": {
-            "type": ["string", "number"],
-            "format": "expose"
+            "oneOf": [
+              { "type": "number" },
+              { 
+                "type": "string", 
+                "pattern": "^\\d{1,5}(-\\d{1,5})?(\/(tcp|udp))?$"
+              }
+            ]
           },
           "uniqueItems": true
         },
@@ -247,7 +254,10 @@
         "group_add": {
           "type": "array",
           "items": {
-            "type": ["string", "number"]
+            "oneOf": [
+              {"type": "string"}, 
+              {"type":"number"}
+            ]
           },
           "uniqueItems": true
         },
@@ -267,7 +277,13 @@
             "options": {
               "type": "object",
               "patternProperties": {
-                "^.+$": {"type": ["string", "number", "null"]}
+                "^.+$": { 
+                  "anyOf": [
+                    {"type": "string"},
+                    {"type": "number"},
+                    {"type": "null"}
+                  ]
+                }
               }
             }
           },
@@ -275,10 +291,10 @@
           "patternProperties": {"^x-": {}}
         },
         "mac_address": {"type": "string"},
-        "mem_limit": {"type": ["number", "string"]},
-        "mem_reservation": {"type": ["string", "integer"]},
+        "mem_limit": {"anyOf":[{"type":"number"},{"type":"string"}]},
+        "mem_reservation": {"anyOf":[{"type":"integer"},{"type":"string"}]},
         "mem_swappiness": {"type": "integer"},
-        "memswap_limit": {"type": ["number", "string"]},
+        "memswap_limit": {"anyOf":[{"type":"number"},{"type":"string"}]},
         "network_mode": {"type": "string"},
         "networks": {
           "oneOf": [
@@ -292,8 +308,8 @@
                       "type": "object",
                       "properties": {
                         "aliases": {"$ref": "#/definitions/list_of_strings"},
-                        "ipv4_address": {"type": "string"},
-                        "ipv6_address": {"type": "string"},
+                        "ipv4_address": {"type": "string", "format": "ipv4"},
+                        "ipv6_address": {"type": "string", "format": "ipv6"},
                         "link_local_ips": {"$ref": "#/definitions/list_of_strings"},
                         "mac_address": {"type": "string"},
                         "priority": {"type": "number"}
@@ -312,24 +328,54 @@
         "oom_kill_disable": {"type": "boolean"},
         "oom_score_adj": {"type": "integer", "minimum": -1000, "maximum": 1000},
         "pid": {"type": ["string", "null"]},
-        "pids_limit": {"type": ["number", "string"]},
+        "pids_limit": {"anyOf":[{"type":"number"},{"type":"string"}]},
         "platform": {"type": "string"},
         "ports": {
           "type": "array",
           "items": {
             "oneOf": [
-              {"type": "number", "format": "ports"},
-              {"type": "string", "format": "ports"},
+              {"type": "number"},
+              {
+                "type": "string", 
+                "pattern": "^((\\d+((\\.\\d+)+|(-\\d+))*):?){1,3}(\/(tcp|udp))?$"
+              },
               {
                 "type": "object",
                 "properties": {
-                  "name": {"type": "string"},
-                  "mode": {"type": "string"},
-                  "host_ip": {"type": "string"},
-                  "target": {"type": "integer"},
-                  "published": {"type": ["string", "integer"]},
-                  "protocol": {"type": "string"},
-                  "app_protocol": {"type": "string"}
+                  "name": {
+                    "type": "string",
+                    "description": "A human-readable name for the port, used to document it's usage within the service"
+                  },
+                  "mode": {
+                    "type": "string", 
+                    "pattern": "^ingress|host$",
+                    "description": "host: For publishing a host port on each node, or ingress: for a port to be load balanced. Defaults to ingress."
+                  },
+                  "host_ip": {
+                    "type": "string", 
+                    "format": "ipv4",
+                    "description": "The Host IP mapping, unspecified means all network interfaces (0.0.0.0)"
+                  },
+                  "target": {
+                    "$ref": "#/definitions/port_format",
+                    "description": "The container port"      
+                  },
+                  "published": {
+                    "anyOf":[
+                      { "$ref": "#/definitions/port_format" },
+                      { "$ref": "#/definitions/port_published_format" }
+                    ],
+                    "description": "The publicly exposed port. It is defined as a string and can be set as a range using syntax start-end. It means the actual port is assigned a remaining available port, within the set range."
+                  },
+                  "protocol": {
+                    "type": "string", 
+                    "pattern": "^tcp|udp$",
+                    "description": "The port protocol (tcp or udp). Defaults to tcp"
+                  },
+                  "app_protocol": {
+                    "type": "string",
+                    "description": "The application protocol (TCP/IP level 4 / OSI level 7) this port is used for. This is optional and can be used as a hint for Compose to offer richer behavior for protocols that it understands"
+                  }
                 },
                 "additionalProperties": false,
                 "patternProperties": {"^x-": {}}
@@ -352,11 +398,11 @@
           "type": "integer"
         },
         "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "shm_size": {"type": ["number", "string"]},
+        "shm_size": {"anyOf":[{"type":"number"},{"type":"string"}]},
         "secrets": {"$ref": "#/definitions/service_config_or_secret"},
         "sysctls": {"$ref": "#/definitions/list_or_dict"},
         "stdin_open": {"type": "boolean"},
-        "stop_grace_period": {"type": "string", "format": "duration"},
+        "stop_grace_period": {"$ref": "#/definitions/duration_format"},
         "stop_signal": {"type": "string"},
         "storage_opt": {"type": "object"},
         "tmpfs": {"$ref": "#/definitions/string_or_list"},
@@ -432,11 +478,11 @@
     },
 
     "healthcheck": {
-      "id": "#/definitions/healthcheck",
+      "$id": "#/definitions/healthcheck",
       "type": "object",
       "properties": {
         "disable": {"type": "boolean"},
-        "interval": {"type": "string", "format": "duration"},
+        "interval": {"$ref": "#/definitions/duration_format"},
         "retries": {"type": "number"},
         "test": {
           "oneOf": [
@@ -444,36 +490,39 @@
             {"type": "array", "items": {"type": "string"}}
           ]
         },
-        "timeout": {"type": "string", "format": "duration"},
-        "start_period": {"type": "string", "format": "duration"},
-        "start_interval": {"type": "string", "format": "duration"}
+        "timeout": {"$ref": "#/definitions/duration_format"},
+        "start_period": {"$ref": "#/definitions/duration_format"},
+        "start_interval": {"$ref": "#/definitions/duration_format"}
       },
       "additionalProperties": false,
       "patternProperties": {"^x-": {}}
     },
     "development": {
-      "id": "#/definitions/development",
+      "$id": "#/definitions/development",
       "type": ["object", "null"],
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}},
       "properties": {
         "watch": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "type": "object",
             "required": ["path", "action"],
+            "additionalProperties": false,
+            "patternProperties": {"^x-": {}},
             "properties": {
-              "ignore": {"type": "array", "items": {"type": "string"}},
               "path": {"type": "string"},
               "action": {"type": "string", "enum": ["rebuild", "sync", "sync+restart"]},
+              "ignore": {"type": "array", "items": {"type": "string"}},
               "target": {"type": "string"}
             }
-          },
-          "additionalProperties": false,
-          "patternProperties": {"^x-": {}}
+          }
         }
       }
     },
     "deployment": {
-      "id": "#/definitions/deployment",
+      "$id": "#/definitions/deployment",
       "type": ["object", "null"],
       "properties": {
         "mode": {"type": "string"},
@@ -484,9 +533,9 @@
           "type": "object",
           "properties": {
             "parallelism": {"type": "integer"},
-            "delay": {"type": "string", "format": "duration"},
+            "delay": {"$ref": "#/definitions/duration_format"},
             "failure_action": {"type": "string"},
-            "monitor": {"type": "string", "format": "duration"},
+            "monitor": {"$ref": "#/definitions/duration_format"},
             "max_failure_ratio": {"type": "number"},
             "order": {"type": "string", "enum": [
               "start-first", "stop-first"
@@ -499,9 +548,9 @@
           "type": "object",
           "properties": {
             "parallelism": {"type": "integer"},
-            "delay": {"type": "string", "format": "duration"},
+            "delay": {"$ref": "#/definitions/duration_format"},
             "failure_action": {"type": "string"},
-            "monitor": {"type": "string", "format": "duration"},
+            "monitor": {"$ref": "#/definitions/duration_format"},
             "max_failure_ratio": {"type": "number"},
             "order": {"type": "string", "enum": [
               "start-first", "stop-first"
@@ -516,7 +565,10 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpus": {"type": ["number", "string"]},
+                "cpus": { "anyOf": [
+                  {"type": "number"},
+                  {"type": "string"}
+                ]},
                 "memory": {"type": "string"},
                 "pids": {"type": "integer"}
               },
@@ -526,7 +578,10 @@
             "reservations": {
               "type": "object",
               "properties": {
-                "cpus": {"type": ["number", "string"]},
+                "cpus": { "anyOf": [
+                  {"type": "number"},
+                  {"type": "string"}
+                ]},
                 "memory": {"type": "string"},
                 "generic_resources": {"$ref": "#/definitions/generic_resources"},
                 "devices": {"$ref": "#/definitions/devices"}
@@ -542,9 +597,9 @@
           "type": "object",
           "properties": {
             "condition": {"type": "string"},
-            "delay": {"type": "string", "format": "duration"},
+            "delay": {"$ref": "#/definitions/duration_format"},
             "max_attempts": {"type": "integer"},
-            "window": {"type": "string", "format": "duration"}
+            "window": {"$ref": "#/definitions/duration_format"}
           },
           "additionalProperties": false,
           "patternProperties": {"^x-": {}}
@@ -570,12 +625,12 @@
           "patternProperties": {"^x-": {}}
         }
       },
-      "additionalProperties": false,
-      "patternProperties": {"^x-": {}}
+      "patternProperties": {"^x-": {}},
+      "additionalProperties": false
     },
 
     "generic_resources": {
-      "id": "#/definitions/generic_resources",
+      "$id": "#/definitions/generic_resources",
       "type": "array",
       "items": {
         "type": "object",
@@ -596,13 +651,18 @@
     },
 
     "devices": {
-      "id": "#/definitions/devices",
+      "$id": "#/definitions/devices",
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
           "capabilities": {"$ref": "#/definitions/list_of_strings"},
-          "count": {"type": ["string", "integer"]},
+          "count": { 
+            "anyOf": [
+              {"type": "string"},
+              {"type": "integer"}
+            ]
+          },
           "device_ids": {"$ref": "#/definitions/list_of_strings"},
           "driver":{"type": "string"},
           "options":{"$ref": "#/definitions/list_or_dict"}
@@ -613,7 +673,7 @@
     },
 
     "include": {
-      "id": "#/definitions/include",
+      "$id": "#/definitions/include",
       "oneOf": [
         {"type": "string"},
         {
@@ -629,7 +689,7 @@
     },
 
     "network": {
-      "id": "#/definitions/network",
+      "$id": "#/definitions/network",
       "type": ["object", "null"],
       "properties": {
         "name": {"type": "string"},
@@ -637,7 +697,7 @@
         "driver_opts": {
           "type": "object",
           "patternProperties": {
-            "^.+$": {"type": ["string", "number"]}
+            "^.+$": {"anyOf":[{"type":"number"},{"type":"string"}]}
           }
         },
         "ipam": {
@@ -649,7 +709,11 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {"type": "string", "format": "subnet_ip_address"},
+                  "subnet": {"anyOf":[
+                    {"$ref": "#/definitions/ipv4_subnet_format"},
+                    {"$ref": "#/definitions/ipv6_subnet_format"}
+                  ]
+                  },
                   "ip_range": {"type": "string"},
                   "gateway": {"type": "string"},
                   "aux_addresses": {
@@ -692,7 +756,7 @@
     },
 
     "volume": {
-      "id": "#/definitions/volume",
+      "$id": "#/definitions/volume",
       "type": ["object", "null"],
       "properties": {
         "name": {"type": "string"},
@@ -721,7 +785,7 @@
     },
 
     "secret": {
-      "id": "#/definitions/secret",
+      "$id": "#/definitions/secret",
       "type": "object",
       "properties": {
         "name": {"type": "string"},
@@ -748,7 +812,7 @@
     },
 
     "config": {
-      "id": "#/definitions/config",
+      "$id": "#/definitions/config",
       "type": "object",
       "properties": {
         "name": {"type": "string"},
@@ -808,7 +872,6 @@
         }
       ]
     },
-
     "string_or_list": {
       "oneOf": [
         {"type": "string"},
@@ -821,14 +884,51 @@
       "items": {"type": "string"},
       "uniqueItems": true
     },
-
+    "duration_format": {
+      "type": "string",
+      "pattern": "^([0-9]+h)?([0-9]+m)?([0-9]+s)?([0-9]+ms)?([0-9]+us)?([0-9]+ns)?$"
+    },
+    "expose_format": {
+      "type": "string",
+      "pattern": "^((6553[0-5])|(655[0-2][0-9])|(65[0-4][0-9]{2})|(6[0-4][0-9]{3})|([1-5][0-9]{4})|([0-5]{0,5})|([0][0-9]{1,4})|([0-9]{1,4}))(-((6553[0-5])|(655[0-2][0-9])|(65[0-4][0-9]{2})|(6[0-4][0-9]{3})|([1-5][0-9]{4})|([0-5]{0,5})|([0][0-9]{1,4})|([0-9]{1,4})))?(/tcp|udp)?$"
+    },
+    "port_published_format": {
+      "type": "string",
+      "pattern": "^((6553[0-5])|(655[0-2][0-9])|(65[0-4][0-9]{2})|(6[0-4][0-9]{3})|([1-5][0-9]{4})|([0-5]{0,5})|([0][0-9]{1,4})|([0-9]{1,4}))(-((6553[0-5])|(655[0-2][0-9])|(65[0-4][0-9]{2})|(6[0-4][0-9]{3})|([1-5][0-9]{4})|([0-5]{0,5})|([0][0-9]{1,4})|([0-9]{1,4})))?$"
+    },
+    "port_format": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "ipv6_subnet_format": {
+      "type": "string",
+      "pattern": "(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/(?:\\d|[12]\\d|3[01])"
+    },
+    "ipv4_subnet_format": {
+      "type": "string",
+      "pattern": "((^|\\.)((25[0-5])|(2[0-4]\\d)|(1\\d\\d)|([1-9]?\\d))){4}\/(?:\\d|[12]\\d|3[01])"
+    },
     "list_or_dict": {
       "oneOf": [
         {
           "type": "object",
           "patternProperties": {
             ".+": {
-              "type": ["string", "number", "boolean", "null"]
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "additionalProperties": false
@@ -841,7 +941,7 @@
       "type": "object",
       "properties": {
         "path": {"type": "string"},
-        "rate": {"type": ["integer", "string"]}
+        "rate": {"anyOf":[{"type":"integer"},{"type":"string"}]}
       },
       "additionalProperties": false
     },
@@ -895,7 +995,7 @@
     },
     "constraints": {
       "service": {
-        "id": "#/definitions/constraints/service",
+        "$id": "#/definitions/constraints/service",
         "anyOf": [
           {"required": ["build"]},
           {"required": ["image"]}

--- a/tests/compose-spec_test.go
+++ b/tests/compose-spec_test.go
@@ -1,0 +1,326 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+func createComposeSpec(spec string) string {
+	return fmt.Sprintf(`
+  {
+    "services": {
+        "a": {
+          "image": "alpine"
+        }
+    },
+    %s
+  }`, spec)
+}
+
+func createComposeSpecService(serviceSpec string) string {
+	return fmt.Sprintf(`
+  {
+    "services": {
+      "service-foo": {
+          %s
+      }
+    }
+  }`, serviceSpec)
+}
+
+func TestComposeSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    string
+		invalid bool
+	}{
+		{
+			name: "[#/nertwork] network ipv4 and ipv6 subnet",
+			spec: createComposeSpec(`
+        "networks": {
+          "front-tier": {
+            "ipam": {
+              "driver": "default",
+              "config": [
+                {"subnet": "172.16.238.0/24"},
+                {"subnet": "0.0.0.0/64"},
+                {"subnet": "2001:3984:3989::/64"},
+                {"subnet": "172.16.238.0/24"},
+                {"subnet": "2001:3984:3989::/64"},
+                {"subnet": "2001:3984:3989::/64"},
+                {"subnet": "1080:0:0:0:8:800:200C:417A/64"},
+                {"subnet": "FF01:0:0:0:0:0:0:101/64"},
+                {"subnet": "0:0:0:0:0:0:0:1/64"},
+                {"subnet": "0:0:0:0:0:0:0:0/64"},
+                {"subnet": "::/64"},
+                {"subnet": "1080::8:800:200C:417A/64"},
+                {"subnet": "::1/64"}
+              ]
+            }
+          }
+        }`),
+		},
+		{
+			name: "[#/x-*] optional x- should be allowed at top level",
+			spec: createComposeSpec(`"x-test":"something"`),
+		},
+		{
+			name: "[#/services/service/expose] expose port has right format",
+			spec: createComposeSpecService(`
+        "expose": [
+          "12345-12345/tcp",
+          "12345-12345/udp",
+          "12345/udp",
+          "12345-12345",
+          "1234-1234",
+          "123-123",
+          "12-12",
+          "1-1",
+          "12345",
+          "1234",
+          "123",
+          "12",
+          "1"
+        ]`),
+		},
+		{
+			name: "[#/services/service/expose] expose port is too long",
+			spec: createComposeSpecService(`
+        "expose": [
+          "123456"
+        ]`),
+			invalid: true,
+		},
+		{
+			name: "[#/services/service/expose] expose second port is too long",
+			spec: createComposeSpecService(`
+        "expose": [
+          "1234-123456"
+        ]`),
+			invalid: true,
+		},
+		{
+			name: "[#/services/service/expose] expose missing first port",
+			spec: createComposeSpecService(`
+        "expose": [
+          "-123"
+        ]`),
+			invalid: true,
+		},
+		{
+			name: "[#/services/service/expose] expose with wrong protocol",
+			spec: createComposeSpecService(`
+        "expose": [
+          "123-123/random"
+        ]`),
+			invalid: true,
+		},
+		{
+			name: "[#/services/service/ports] ports must have the [HOST:]CONTAINER[/PROTOCOL] format",
+			spec: createComposeSpecService(`
+        "ports": [
+          "3000",
+          "3000-3005",
+          "8000:8000",
+          "9090-9091:8080-8081",
+          "49100:22",
+          "8000-9000:80",
+          "127.0.0.1:8001:8001",
+          "127.0.0.1:5000-5010:5000-5010",
+          "6060:6060/udp"
+        ]`),
+		},
+		{
+			name: "[#/services/service/ports] ports cannot be empty",
+			spec: createComposeSpecService(`
+        "ports": [
+          ""
+        ]`),
+			invalid: true,
+		},
+		{
+			name: "[#/services/service/ports] ports cannot be negative",
+			spec: createComposeSpecService(`
+        "ports": [
+          "-3000"
+        ]`),
+			invalid: true,
+		},
+		{
+			name: "[#/services/service/ports] ports cannot be imcomplete",
+			spec: createComposeSpecService(`
+        "ports": [
+          ":80"
+        ]`),
+			invalid: true,
+		},
+		{
+			name: "[#/services/service/ports] ports must have valid protocol",
+			spec: createComposeSpecService(`
+        "ports": [
+          "6060:6060/random"
+        ]`),
+			invalid: true,
+		},
+		{
+			name: "[#/services/service/ports] port protocol should be tcp or udp",
+			spec: createComposeSpecService(`
+        "ports": [
+          { "protocol": "tcp" },
+          { "protocol": "udp" }
+        ]`),
+		},
+		{
+			name: "[#/services/service/ports] port protocol should ONLY be tcp or udp",
+			spec: createComposeSpecService(`
+        "ports": [
+          { "protocol": "random" }
+        ]`),
+			invalid: true,
+		},
+		{
+			name: "[#/services/service/ports] port published within range",
+			spec: createComposeSpecService(`
+        "ports": [
+          { "published": "0" },
+          { "published": "00000" },
+          { "published": "0-0" },
+          { "published": "00000-00000" },
+          { "published": "65535" },
+          { "published": "65535-65535" },
+          { "published": 0 },
+          { "published": 65535 }
+        ]`),
+		},
+		{
+			name: "[#/services/service/ports] port published should not be over 65535 (integer)",
+			spec: createComposeSpecService(`
+        "ports": [
+          { "published": 65536 }
+        ]`),
+			invalid: true,
+		},
+		{
+			name: "[#/services/service/ports] published should not be over 65535 (string)",
+			spec: createComposeSpecService(`
+        "ports": [
+          { "published": "65536" }
+        ]`),
+			invalid: true,
+		},
+		{
+			name: "[#/services/service/ports] port published should not be over 65535 (string)",
+			spec: createComposeSpecService(`
+        "ports": [
+          { "published": "65535-65536" }
+        ]`),
+			invalid: true,
+		},
+		{
+			name: "[#/services/service/stop_grace_period] must be a valid duration (micro second)",
+			spec: createComposeSpecService(`"stop_grace_period": "10us"`),
+		},
+		{
+			name: "[#/services/service/stop_grace_period] must be a valid duration (milisecond)",
+			spec: createComposeSpecService(`"stop_grace_period": "10ms"`),
+		},
+		{
+			name: "[#/services/service/stop_grace_period] must be a valid duration (second)",
+			spec: createComposeSpecService(`"stop_grace_period": "10s"`),
+		},
+		{
+			name: "[#/services/service/stop_grace_period] must be a valid duration (minute)",
+			spec: createComposeSpecService(`"stop_grace_period": "10m"`),
+		},
+		{
+			name: "[#/services/service/stop_grace_period] must be a valid duration (hour)",
+			spec: createComposeSpecService(`"stop_grace_period": "10h"`),
+		},
+		{
+			name: "[#/services/service/stop_grace_period] must be a valid duration (combined)",
+			spec: createComposeSpecService(`"stop_grace_period": "1h2m3s4ms5us"`),
+		},
+		{
+			name:    "[services/service/stop_grace_period] cannot be given a duration with wrong order",
+			spec:    createComposeSpecService(`"stop_grace_period": "1s10h"`),
+			invalid: true,
+		},
+		{
+			name:    "stop_grace_period cannot be given a duration with wrong unit",
+			spec:    createComposeSpecService(`"stop_grace_period": "1kg"`),
+			invalid: true,
+		},
+		{
+			name: "[#/services/service/deploy/rollback_config/delay] is a duration",
+			spec: createComposeSpecService(`"deploy": {"rollback_config": {"delay": "1h2s3ms4us"}}`),
+		},
+		{
+			name: "[#/services/service/deploy/rollback_config/monitor] is a duration",
+			spec: createComposeSpecService(`"deploy": {"rollback_config": {"monitor": "1h2s3ms4us5ns"}}`),
+		},
+		{
+			name:    "[services/service/develop/watch] should require at least one element",
+			spec:    createComposeSpecService(`"develop": { "watch": [] }`),
+			invalid: true,
+		},
+		{
+			name:    "[services/service/develop/watch] should require at least one element with path and action",
+			spec:    createComposeSpecService(`"develop": { "watch": [{"action":"rebuild"}] }`),
+			invalid: true,
+		},
+		{
+			name: "[#/services/service/develop/watch] should require action and path",
+			spec: createComposeSpecService(`
+			"develop": {
+				"x-develop": "foo",
+				"watch": [
+					{ 
+						"action": "sync", 
+						"path": "foo",
+						"x-watch": "foo"
+					}
+				]
+			}`),
+		},
+		{
+			name: "[#/include] should be a string array",
+			spec: createComposeSpec(`"include": [ "foo" ]`),
+		},
+		{
+			name: "[#/include] should be a object array",
+			spec: createComposeSpec(`"include": [ { "path": "foo"} ]`),
+		},
+	}
+	sch, err := jsonschema.Compile("../schema/compose-spec.json")
+	if err != nil {
+		t.Fatalf("\033[31mcompose-spec.json is not valid. Skipping tests.\n\033[0m--- FAIL: %s", err)
+		return
+	}
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+			var data interface{}
+			err = json.Unmarshal([]byte(tt.spec), &data)
+			if err != nil {
+				t.Logf("an error was thrown on Unmarshal. NOTE: make sure in array test element case does not have a ',' in the last element\n%s\n", tt.spec)
+				t.FailNow()
+			}
+
+			err = sch.Validate(data)
+			if !tt.invalid {
+				if err != nil {
+					t.Logf("the spec should be valid\n%s\nERROR: %s", tt.spec, err)
+					t.FailNow()
+				}
+			} else {
+				if err == nil {
+					t.Logf("the spec should NOT be valid\n%s\nERROR: %s", tt.spec, err)
+					t.Fail()
+				}
+			}
+		})
+	}
+}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,0 +1,5 @@
+module compose-spec/tests
+
+go 1.22.0
+
+require github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1,0 +1,2 @@
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the compose schema, which was not previously valid. I changed the spec to Draft07.

Some of the string formats I needed to add a regex pattern, since some of them were only available in 2019 json schema spec. 

Also added tests to validate that the schema compiles, and some cases related to the added changes to make sure the behaviour is still the same according to the docker compose documentation.



