### PR TITLE
Add driver_opts to services.networks

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -1270,6 +1270,23 @@ networks:
 
 `mac_address` sets the MAC address used by the service container when connecting to this particular network.
 
+### driver_opts
+
+[![unreleased](https://img.shields.io/badge/compose-unreleased-blue?style=flat-square)](https://github.com/docker/compose)
+
+`driver_opts` specifies a list of options as key-value pairs to pass to the driver. These options are
+driver-dependent. Consult the driver's documentation for more information.
+
+```yml
+services:
+  app:
+    networks:
+      app_net:
+        driver_opts:
+          foo: "bar"
+          baz: 1
+```
+
 ### priority
 
 `priority` indicates in which order Compose connects the service’s containers to its

--- a/spec.md
+++ b/spec.md
@@ -1483,6 +1483,23 @@ networks:
 
 `mac_address` sets the MAC address used by the service container when connecting to this particular network.
 
+### driver_opts
+
+[![unreleased](https://img.shields.io/badge/compose-unreleased-blue?style=flat-square)](https://github.com/docker/compose)
+
+`driver_opts` specifies a list of options as key-value pairs to pass to the driver. These options are
+driver-dependent. Consult the driver's documentation for more information.
+
+```yml
+services:
+  app:
+    networks:
+      app_net:
+        driver_opts:
+          foo: "bar"
+          baz: 1
+```
+
 ### priority
 
 `priority` indicates in which order Compose connects the service’s containers to its


### PR DESCRIPTION
**What this PR does / why we need it**:

It's possible to set driver options when creating a network using compose ... [compose spec](https://github.com/robmry/compose-go/blob/b08e2159a8b1fd78444c2ef434bd4913d74697d1/schema/compose-spec.json#L637-L641) / [engine API](https://github.com/moby/moby/blob/9d07820b221db010bf1bdc26ca904468804ca712/api/swagger.yaml#L10134-L10138).

But not when connecting an endpoint to a network ... [compose spec](https://github.com/robmry/compose-go/blob/b08e2159a8b1fd78444c2ef434bd4913d74697d1/schema/compose-spec.json#L293-L300) / [engine API](https://github.com/moby/moby/blob/9d07820b221db010bf1bdc26ca904468804ca712/api/swagger.yaml#L2541-L2544).

The API field isn't new, but upcoming change https://github.com/moby/moby/pull/47686 means it'll be useful for setting per-interface sysctls.

https://github.com/compose-spec/compose-go/pull/627 adds the types, this updates the spec to match.

(`compose` will need an update to pass driver-opts into the engine API's `EndpointSettings`.)

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
n/a


