### PR TITLE
05-services.md: fix grammar (it's → its)

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -1459,7 +1459,7 @@ expressed in the short form.
 - `app_protocol`: The application procotol (TCP/IP level 4 / OSI level 7) this port is used for. This is optional and can be used as a hint for Compose to offer richer behavior for protocols that it understands.
 [![Compose v2.26.0](https://img.shields.io/badge/compose-v2.26.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.26.0)
 - `mode`: `host`: For publishing a host port on each node, or `ingress` for a port to be load balanced. Defaults to `ingress`.
-- `name`: A human-readable name for the port, used to document it's usage within the service
+- `name`: A human-readable name for the port, used to document its usage within the service
 
 ```yml
 ports:

--- a/spec.md
+++ b/spec.md
@@ -1672,7 +1672,7 @@ expressed in the short form.
 - `app_protocol`: The application procotol (TCP/IP level 4 / OSI level 7) this port is used for. This is optional and can be used as a hint for Compose to offer richer behavior for protocols that it understands.
 [![Compose v2.26.0](https://img.shields.io/badge/compose-v2.26.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.26.0)
 - `mode`: `host`: For publishing a host port on each node, or `ingress` for a port to be load balanced. Defaults to `ingress`.
-- `name`: A human-readable name for the port, used to document it's usage within the service
+- `name`: A human-readable name for the port, used to document its usage within the service
 
 ```yml
 ports:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes grammar to make the spec easier to read.

**Which issue(s) this PR fixes**:

N/A