### PR TITLE
remove host or none section wich is wrong

### DIFF
--- a/06-networks.md
+++ b/06-networks.md
@@ -69,44 +69,6 @@ networks:
     driver: overlay
 ```
 
-Default and available values are platform specific. Compose supports the following drivers:
-`none` and `host`
-
-- `host`: Use the host's networking stack.
-- `none`: Turn off networking.
-
-#### host or none
-
-The syntax for using built-in networks such as `host` and `none` is different, as such networks implicitly exist outside
-the scope of Compose. To use them, you must define an external network with the name `host` or `none` and
-an alias that Compose can use (`hostnet` and `nonet` in the following example), then grant the service
-access to that network using its alias.
-
-```yml
-services:
-  web:
-    networks:
-      hostnet: {}
-
-networks:
-  hostnet:
-    external: true
-    name: host
-```
-
-```yml
-services:
-  web:
-    ...
-    networks:
-      nonet: {}
-
-networks:
-  nonet:
-    external: true
-    name: none
-```
-
 ### driver_opts
 
 `driver_opts` specifies a list of options as key-value pairs to pass to the driver. These options are

--- a/spec.md
+++ b/spec.md
@@ -2126,44 +2126,6 @@ networks:
     driver: overlay
 ```
 
-Default and available values are platform specific. Compose supports the following drivers:
-`none` and `host`
-
-- `host`: Use the host's networking stack.
-- `none`: Turn off networking.
-
-#### host or none
-
-The syntax for using built-in networks such as `host` and `none` is different, as such networks implicitly exist outside
-the scope of Compose. To use them, you must define an external network with the name `host` or `none` and
-an alias that Compose can use (`hostnet` and `nonet` in the following example), then grant the service
-access to that network using its alias.
-
-```yml
-services:
-  web:
-    networks:
-      hostnet: {}
-
-networks:
-  hostnet:
-    external: true
-    name: host
-```
-
-```yml
-services:
-  web:
-    ...
-    networks:
-      nonet: {}
-
-networks:
-  nonet:
-    external: true
-    name: none
-```
-
 ### driver_opts
 
 `driver_opts` specifies a list of options as key-value pairs to pass to the driver. These options are


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes documentation about using `host` and `none` as pseudo-network drivers, while those are just a `network_mode` (can't be combined with another network). Not sure where this came from, maybe specific to docker swarm as this was introduced in docker docs with compose file format v3

**Which issue(s) this PR fixes**:
Fixes https://github.com/docker/compose/issues/11055


