### PR TITLE
feat: allow x-* in depends_on

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -192,6 +192,7 @@
                 "^[a-zA-Z0-9._-]+$": {
                   "type": "object",
                   "additionalProperties": false,
+                  "patternProperties": {"^x-": {}},
                   "properties": {
                     "restart": {"type": "boolean"},
                     "required": {


### PR DESCRIPTION
**What this PR does / why we need it**:
Changed `composer-spec.json` to support `x-*` properties in the `depends_on` section


**Which issue(s) this PR fixes**:
Fixes [#11930](https://github.com/docker/compose/issues/11930)


