### PR TITLE
Update compose-spec.json: Allow strings as includes

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -20,7 +20,6 @@
     "include": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/include"
       },
       "description": "compose sub-projects to be included."


### PR DESCRIPTION
**What this PR does / why we need it**:
Validation tooling warns about includes using strings directly. See attachment.
It is however allowed, which is already specified on the $ref definition. I think the additional `type: "object"` just overrides it.

![Skärmavbild 2024-07-02 kl  12 49 30](https://github.com/compose-spec/compose-spec/assets/593305/ef8db464-8716-46de-be9a-e9ca5ff7b0c1)

