### PR TITLE
bump peter-evans/create-pull-request action to version v6

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -21,7 +21,7 @@ jobs:
         run: git diff schema/compose-spec.json
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           title: Update compose-spec.json
           commit-message: Update compose-spec.json


### PR DESCRIPTION
**What this PR does / why we need it**:
We are using an old version of the `create-pull-request` action with potential security issues


