### PR TITLE
add release versions for `entitlements` and  `driver_opts` attributes

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -1272,7 +1272,7 @@ networks:
 
 ### driver_opts
 
-[![unreleased](https://img.shields.io/badge/compose-unreleased-blue?style=flat-square)](https://github.com/docker/compose)
+[![Compose v2.27.1](https://img.shields.io/badge/compose-v2.27.1-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.27.1)
 
 `driver_opts` specifies a list of options as key-value pairs to pass to the driver. These options are
 driver-dependent. Consult the driver's documentation for more information.

--- a/build.md
+++ b/build.md
@@ -291,7 +291,7 @@ Illustrative examples of how this is used in Buildx can be found
 
 ## entitlements
 
-[![unreleased](https://img.shields.io/badge/compose-unreleased-blue?style=flat-square)](https://github.com/docker/compose)
+[![Compose v2.27.0](https://img.shields.io/badge/compose-v2.27.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.27.0)
 
  `entitlements` defines extra privileged entitlements to be allowed during the build
  

--- a/spec.md
+++ b/spec.md
@@ -1485,7 +1485,7 @@ networks:
 
 ### driver_opts
 
-[![unreleased](https://img.shields.io/badge/compose-unreleased-blue?style=flat-square)](https://github.com/docker/compose)
+[![Compose v2.27.1](https://img.shields.io/badge/compose-v2.27.1-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.27.1)
 
 `driver_opts` specifies a list of options as key-value pairs to pass to the driver. These options are
 driver-dependent. Consult the driver's documentation for more information.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the release versions for both `driver_opts` and `entitlements` attributes

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
N/A


