### PR TITLE
fix: Fix missing quotes

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -647,7 +647,7 @@ When not explicitly set, `tcp` protocol is used.
 expose:
   - "3000"
   - "8000"
-  - "8080-8085/tcp
+  - "8080-8085/tcp"
 ```
 
 > **Note**

--- a/spec.md
+++ b/spec.md
@@ -860,7 +860,7 @@ When not explicitly set, `tcp` protocol is used.
 expose:
   - "3000"
   - "8000"
-  - "8080-8085/tcp
+  - "8080-8085/tcp"
 ```
 
 > **Note**


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a simple PR that fixes missing quotes on the `expose` part of the Services documentation.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #528


