### PR TITLE
Update compose-spec.json: remove invalid fields from array

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -483,9 +483,7 @@
             },
             "additionalProperties": false,
             "patternProperties": {"^x-": {}}
-          },
-          "additionalProperties": false,
-          "patternProperties": {"^x-": {}}
+          }
         }
       }
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

The 'additionalProperties' and 'patternProperties' are being declared for an array type, which is invalid. They are also declared for the items of the array, so they can be removed. Their presence is causing issues converting this jsonschema to its cuelang representation.

**Which issue(s) this PR fixes**:
Fixes [534.](https://github.com/compose-spec/compose-spec/issues/534)



