### PR TITLE
relative paths are resolved base on project directory

### DIFF
--- a/build.md
+++ b/build.md
@@ -91,7 +91,7 @@ Alternatively `build` can be an object with fields defined as follows:
 
 `context` defines either a path to a directory containing a Dockerfile, or a URL to a git repository.
 
-When the value supplied is a relative path, it is interpreted as relative to the location of the Compose file.
+When the value supplied is a relative path, it is interpreted as relative to the project directory.
 Compose warns you about the absolute path used to define the build context as those prevent the Compose file
 from being portable.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
avoid ambiguity regarding relative path used as build context

**Which issue(s) this PR fixes**:
Fixes https://github.com/docker/compose/issues/12008


