### PR TITLE
clarify condition compose will parse string as variable

### DIFF
--- a/12-interpolation.md
+++ b/12-interpolation.md
@@ -26,6 +26,10 @@ Interpolation can also be nested:
 Other extended shell-style features, such as `${VARIABLE/foo/bar}`, are not
 supported by Compose.
 
+Compose will process any string following a `$` sign as long as it makes it
+a valid variable definition: either an alphanumeric name (`[_a-z][_a-z0-9]*`)
+or a braced string starting with `${`. In other circumstances, it will be preserved without attempt to interpolate a value.
+
 You can use a `$$` (double-dollar sign) when your configuration needs a literal
 dollar sign. This also prevents Compose from interpolating a value, so a `$$`
 allows you to refer to environment variables that you don't want processed by

--- a/spec.md
+++ b/spec.md
@@ -2854,6 +2854,10 @@ Interpolation can also be nested:
 Other extended shell-style features, such as `${VARIABLE/foo/bar}`, are not
 supported by Compose.
 
+Compose will process any string following a `$` sign as long as it makes it
+a valid variable definition: either an alphanumeric name (`[_a-z][_a-z0-9]*`)
+or a braced string starting with `${`. In other circumstances, it will be preserved without attempt to interpolate a value.
+
 You can use a `$$` (double-dollar sign) when your configuration needs a literal
 dollar sign. This also prevents Compose from interpolating a value, so a `$$`
 allows you to refer to environment variables that you don't want processed by


### PR DESCRIPTION
**What this PR does / why we need it**:

the exact implementation of compose variable parser should not be defined in the spec, still we can clarify a bit condition a `$` sign won't trigger a parser error.

**Which issue(s) this PR fixes**:
Fixes https://github.com/docker/compose/issues/12287


