### PR TITLE
Add network option enable_ipv4 (for moby 28.0)

### DIFF
--- a/06-networks.md
+++ b/06-networks.md
@@ -95,6 +95,19 @@ networks:
     attachable: true
 ```
 
+### enable_ipv4
+
+[![unreleased](https://img.shields.io/badge/compose-unreleased-blue?style=flat-square)](https://github.com/docker/compose)
+
+`enable_ipv4` can be used to disable IPv4 address assignment.
+
+```yml
+  networks:
+    ip6net:
+      enable_ipv4: false
+      enable_ipv6: true
+```
+
 ### enable_ipv6
 
 `enable_ipv6` enables IPv6 address assignment.

--- a/06-networks.md
+++ b/06-networks.md
@@ -97,7 +97,13 @@ networks:
 
 ### enable_ipv6
 
-`enable_ipv6` enables IPv6 networking. For an example, see step four of [Create an IPv6 network](https://docs.docker.com/config/daemon/ipv6/).
+`enable_ipv6` enables IPv6 address assignment.
+
+```yml
+  networks:
+    ip6net:
+      enable_ipv6: true
+```
 
 ## external
 

--- a/spec.md
+++ b/spec.md
@@ -2269,7 +2269,13 @@ networks:
 
 ### enable_ipv6
 
-`enable_ipv6` enables IPv6 networking. For an example, see step four of [Create an IPv6 network](https://docs.docker.com/config/daemon/ipv6/).
+`enable_ipv6` enables IPv6 address assignment.
+
+```yml
+  networks:
+    ip6net:
+      enable_ipv6: true
+```
 
 ## external
 

--- a/spec.md
+++ b/spec.md
@@ -2267,6 +2267,19 @@ networks:
     attachable: true
 ```
 
+### enable_ipv4
+
+[![unreleased](https://img.shields.io/badge/compose-unreleased-blue?style=flat-square)](https://github.com/docker/compose)
+
+`enable_ipv4` can be used to disable IPv4 address assignment.
+
+```yml
+  networks:
+    ip6net:
+      enable_ipv4: false
+      enable_ipv6: true
+```
+
 ### enable_ipv6
 
 `enable_ipv6` enables IPv6 address assignment.


### PR DESCRIPTION
**What this PR does / why we need it**:

**_Update description of option enable_ipv6_**

- "enables IPv6 networking" -> "enables IPv6 address assignment"
  - aligns with updated CLI help text
- Replace ref to an engine docs "step 4" that doesn't exist with an inline example.

**_Add option enable_ipv4_**

The plan is to hook this up to the network `CreateOptions.EnableIPv4` field that will be added in moby 28.0, https://github.com/moby/moby/pull/48271.