### PR TITLE
Add network endpoint option gw_priority (for moby 28.0)

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -1328,6 +1328,31 @@ services:
           baz: 1
 ```
 
+### gw_priority
+
+[![Compose NEXT RELEASE](https://img.shields.io/badge/compose-NEXT-blue?style=flat-square)](https://github.com/docker/compose/releases/NEXT)
+
+The network with the highest `gw_priority` is selected as the default gateway for the service container.
+If unspecified, the default value is 0.
+
+In the following example, `app_net_2` will be selected as the default gateway.
+
+```yaml
+services:
+  app:
+    image: busybox
+    command: top
+    networks:
+      app_net_1:
+      app_net_2:
+        gw_priority: 1
+      app_net_3:
+networks:
+  app_net_1:
+  app_net_2:
+  app_net_3:
+```
+
 ### priority
 
 `priority` indicates in which order Compose connects the service’s containers to its

--- a/05-services.md
+++ b/05-services.md
@@ -1358,7 +1358,16 @@ networks:
 `priority` indicates in which order Compose connects the service’s containers to its
 networks. If unspecified, the default value is 0.
 
-In the following example, the app service connects to `app_net_1` first as it has the highest priority. It then connects to `app_net_3`, then `app_net_2`, which uses the default priority value of 0.
+_If the container runtime accepts a `mac_address` attribute at service level, it is
+applied to the network with the highest `priority`. In other cases, use attribute
+`networks.mac_address`._
+
+_`priority` does not affect which network is selected as the default gateway. Use the
+[`gw_priority`](#gw_priority) field for that._
+
+_`priority` does not control the order in which networks connections are added to
+the container, it cannot be used to determine the device name (`eth0` etc.) in the
+container._
 
 ```yaml
 services:

--- a/spec.md
+++ b/spec.md
@@ -1541,6 +1541,31 @@ services:
           baz: 1
 ```
 
+### gw_priority
+
+[![Compose NEXT RELEASE](https://img.shields.io/badge/compose-NEXT-blue?style=flat-square)](https://github.com/docker/compose/releases/NEXT)
+
+The network with the highest `gw_priority` is selected as the default gateway for the service container.
+If unspecified, the default value is 0.
+
+In the following example, `app_net_2` will be selected as the default gateway.
+
+```yaml
+services:
+  app:
+    image: busybox
+    command: top
+    networks:
+      app_net_1:
+      app_net_2:
+        gw_priority: 1
+      app_net_3:
+networks:
+  app_net_1:
+  app_net_2:
+  app_net_3:
+```
+
 ### priority
 
 `priority` indicates in which order Compose connects the service’s containers to its

--- a/spec.md
+++ b/spec.md
@@ -1571,7 +1571,16 @@ networks:
 `priority` indicates in which order Compose connects the service’s containers to its
 networks. If unspecified, the default value is 0.
 
-In the following example, the app service connects to `app_net_1` first as it has the highest priority. It then connects to `app_net_3`, then `app_net_2`, which uses the default priority value of 0.
+_If the container runtime accepts a `mac_address` attribute at service level, it is
+applied to the network with the highest `priority`. In other cases, use attribute
+`networks.mac_address`._
+
+_`priority` does not affect which network is selected as the default gateway. Use the
+[`gw_priority`](#gw_priority) field for that._
+
+_`priority` does not control the order in which networks connections are added to
+the container, it cannot be used to determine the device name (`eth0` etc.) in the
+container._
 
 ```yaml
 services:


### PR DESCRIPTION
**What this PR does / why we need it**:

**_Add networks.gw_priority_**

The plan is to hook this up to the `EndpointSettings.GwPriority` field that will be added in moby 28.0, https://github.com/moby/moby/pull/48936

**_Update description of networks.priority_**

Since https://github.com/docker/compose/pull/11429, Compose includes all network endpoints in the initial create request to the moby API ... the network with the highest priority becomes the "primary" endpoint, but there's no other ordering because the endpoints are passed in a map.

Even before that change, it did not influence moby's selection of a default gateway. It would have influenced the container's device name (they're numbered sequentially when endpoints are added to a container, for example `eth0` `eth1` etc), but that ordering was not retained over a container restart.

_This `priority` field should probably be deprecated, but I'm not sure of the rules for that or how to show it ... happy to update!_


