### PR TITLE
Fix line breaks in mermaid diagrams

### DIFF
--- a/02-model.md
+++ b/02-model.md
@@ -50,25 +50,23 @@ Both services communicate with each other on an isolated back-tier network, whil
             bs["`**database**`"]
         end
         style B2 fill:#ccd6e8, stroke-width:0px
-        
     end
     style TOP fill:transparent, stroke-width:2px, stroke:#62affb, stroke-dasharray: 5 5
-        key[ro= read only\nr+w = read write]
-        style key fill:transparent, stroke-width:0px,text-align: left, size: 94px
-        
+        key[ro= read only<br>r+w = read write]
+        style key fill:transparent, stroke-width:0px, text-align: left, size: 94px
         direction TB
-        id2(Server\nCertificate)
-        id1(HTTP\nConfiguration)
+        id2(Server Certificate)
+        id1(HTTP Configuration)
         id1 & id2 -.-|ro| B1
         style id1 stroke:#000,stroke-width:1px,stroke-dasharray: 10
         style id2 stroke:#000,stroke-width:1px,stroke-dasharray: 10
-        B2 ==r+w==> id3[(Persistent\nVolume)]
+        B2 ==r+w==> id3[(Persistent<br>Volume)]
     end
     style A fill:#eeeeee, stroke-width:0px
     direction LR
-    id4[External\nUser] ---id5(((443)))--->|Frontend\nNetwork| B1
+    id4[External User] ---id5(((443)))--->|Frontend<br>Network| B1
     style id4 stroke:#000,stroke-width:2px
-    B1 --Backend\nNetwork--> B2
+    B1 --Backend<br>Network--> B2
 ```
 
 The example application is composed of the following parts:

--- a/spec.md
+++ b/spec.md
@@ -84,25 +84,23 @@ Both services communicate with each other on an isolated back-tier network, whil
             bs["`**database**`"]
         end
         style B2 fill:#ccd6e8, stroke-width:0px
-        
     end
     style TOP fill:transparent, stroke-width:2px, stroke:#62affb, stroke-dasharray: 5 5
-        key[ro= read only\nr+w = read write]
-        style key fill:transparent, stroke-width:0px,text-align: left, size: 94px
-        
+        key[ro= read only<br>r+w = read write]
+        style key fill:transparent, stroke-width:0px, text-align: left, size: 94px
         direction TB
-        id2(Server\nCertificate)
-        id1(HTTP\nConfiguration)
+        id2(Server Certificate)
+        id1(HTTP Configuration)
         id1 & id2 -.-|ro| B1
         style id1 stroke:#000,stroke-width:1px,stroke-dasharray: 10
         style id2 stroke:#000,stroke-width:1px,stroke-dasharray: 10
-        B2 ==r+w==> id3[(Persistent\nVolume)]
+        B2 ==r+w==> id3[(Persistent<br>Volume)]
     end
     style A fill:#eeeeee, stroke-width:0px
     direction LR
-    id4[External\nUser] ---id5(((443)))--->|Frontend\nNetwork| B1
+    id4[External User] ---id5(((443)))--->|Frontend<br>Network| B1
     style id4 stroke:#000,stroke-width:2px
-    B1 --Backend\nNetwork--> B2
+    B1 --Backend<br>Network--> B2
 ```
 
 The example application is composed of the following parts:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the rendering of line breaks in Mermaid diagrams by replacing `\n` with `<br>`, as Mermaid uses `<br>` for line breaks.

Additionally, I replaced some line breaks with spaces to match the formatting in the following document:
- doc: https://docs.docker.com/compose/images/compose-application.webp
- image: https://raw.githubusercontent.com/docker/docs/refs/heads/main/content/manuals/compose/images/compose-application.webp

**Which issue(s) this PR fixes**:

Fixes #578 
