### PR TITLE
services: add api-socket to service volumes types

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -1945,7 +1945,7 @@ it is the runtime's decision to assign a UTS namespace, if supported. Available 
 
 ## volumes
 
-`volumes` define mount host paths or named volumes that are accessible by service containers. You can use `volumes` to define multiple types of mounts; `volume`, `bind`, `tmpfs`, `image` or `npipe`. 
+`volumes` define mount host paths or named volumes that are accessible by service containers. You can use `volumes` to define multiple types of mounts; `volume`, `bind`, `tmpfs`, `image`, `npipe`, `cluster` or `api-socket`.
 
 If the mount is a host path and is only used by a single service, it can be declared as part of the service
 definition. To reuse a volume across multiple services, a named
@@ -2002,7 +2002,7 @@ The short syntax uses a single string with colon-separated values to specify a v
 The long form syntax allows the configuration of additional fields that can't be
 expressed in the short form.
 
-- `type`: The mount type. Either `volume`, `bind`, `tmpfs`, `image`, `npipe`, or `cluster`
+- `type`: The mount type. Either `volume`, `bind`, `tmpfs`, `image`, `npipe`, `cluster` or `api-socket`
 - `source`: The source of the mount, a path on the host for a bind mount, a docker image reference for an 
   image mount, or the name of a volume defined in the
   [top-level `volumes` key](07-volumes.md). Not applicable for a tmpfs mount.

--- a/spec.md
+++ b/spec.md
@@ -2156,7 +2156,7 @@ it is the runtime's decision to assign a UTS namespace, if supported. Available 
 
 ## volumes
 
-`volumes` define mount host paths or named volumes that are accessible by service containers. You can use `volumes` to define multiple types of mounts; `volume`, `bind`, `tmpfs`, `image` or `npipe`. 
+`volumes` define mount host paths or named volumes that are accessible by service containers. You can use `volumes` to define multiple types of mounts; `volume`, `bind`, `tmpfs`, `image`, `npipe`, `cluster` or `api-socket`.
 
 If the mount is a host path and is only used by a single service, it can be declared as part of the service
 definition. To reuse a volume across multiple services, a named
@@ -2213,7 +2213,7 @@ The short syntax uses a single string with colon-separated values to specify a v
 The long form syntax allows the configuration of additional fields that can't be
 expressed in the short form.
 
-- `type`: The mount type. Either `volume`, `bind`, `tmpfs`, `image`, `npipe`, or `cluster`
+- `type`: The mount type. Either `volume`, `bind`, `tmpfs`, `image`, `npipe`, `cluster` or `api-socket`
 - `source`: The source of the mount, a path on the host for a bind mount, a docker image reference for an 
   image mount, or the name of a volume defined in the
   [top-level `volumes` key](07-volumes.md). Not applicable for a tmpfs mount.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a similarly quick way to mount the docker socket as proposed in https://github.com/docker/cli/pull/5858.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #

Let me know if we need further spec documentation.

