### PR TITLE
Add details about the latest tag for PullPolicy Missing

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -1766,6 +1766,7 @@ events.
 * `missing`: Compose pulls the image only if it's not available in the platform cache.
    This is the default option if you are not also using the [Compose Build Specification](build.md).
   `if_not_present` is considered an alias for this value for backward compatibility.
+   The `latest` tag is always pulled even when the `missing` pull policy is used.
 * `build`: Compose builds the image. Compose rebuilds the image if it's already present.
 * `daily`: Compose checks the registry for image updates if the last pull took place more than 24 hours ago.
 * `weekly`: Compose checks the registry for image updates if the last pull took place more than 7 days ago.

--- a/spec.md
+++ b/spec.md
@@ -1977,6 +1977,7 @@ events.
 * `missing`: Compose pulls the image only if it's not available in the platform cache.
    This is the default option if you are not also using the [Compose Build Specification](build.md).
   `if_not_present` is considered an alias for this value for backward compatibility.
+   The `latest` tag is always pulled even when the `missing` pull policy is used.
 * `build`: Compose builds the image. Compose rebuilds the image if it's already present.
 * `daily`: Compose checks the registry for image updates if the last pull took place more than 24 hours ago.
 * `weekly`: Compose checks the registry for image updates if the last pull took place more than 7 days ago.


### PR DESCRIPTION
**What this PR does / why we need it**:

The spec does not give details about the behavior of `PullPolicyMissing` when the `latest` tag is used. From the current docker compose implementation, it looks like `latest` is always pulled, regardless of the usage of PullPolicyMissing. I'm proposing to align the specs (and the docs) with the behavior to reduce confusion.

Source: https://github.com/docker/compose/blob/04b8ac5fe4b9801953d1e6bff7465f4fe8bff377/pkg/compose/pull.go#L167
