### PR TITLE
add develop.watch.initial_sync attribute to the specification

### DIFF
--- a/develop.md
+++ b/develop.md
@@ -23,6 +23,7 @@ services:
         # sync static content
         - path: ./webapp/html
           action: sync
+          initial_sync: true
           target: /var/www
           ignore:
             - node_modules/
@@ -117,6 +118,12 @@ services:
 > 
 > In many cases `include` pattern will start with a wildcard (`*`) character. This has special meaning in YAML syntax
 > to define an [alias node](https://yaml.org/spec/1.2.2/#alias-nodes) so you'll have to wrap pattern expression with quotes.
+
+#### initial_sync
+
+When using `sync+x` actions, it can be useful to ensure that files inside containers are up to date at the start of a new watch session.
+
+The `initial_sync` attribute instructs the Compose runtime, if containers for the service already exist, to check that the files from the path attribute are in sync within the service containers.
 
 #### path
 


### PR DESCRIPTION
**What this PR does / why we need it**:
x-initialSync attribute was there for more than a year as an experimental feature to synchronize host content with services containers when sync+x triggers are setup, we think it could be now officially part of the specification

**Which issue(s) this PR fixes**:

Fixes https://github.com/docker/docs/issues/23345


