### PR TITLE
Fix `baseurl` in Jekyll configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ description: >
   A specification for developer-centric application definition used in Cloud
   Native Applications.
 markdown: kramdown
+baseurl: /compose-spec
 defaults:
   - scope:
       path: ""


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix `site.url` value in Jekyll. 

Currently link from logo in https://compose-spec.github.io/compose-spec/ leads to `https://compose-spec.github.io/`, but it should be `https://compose-spec.github.io/compose-spec/`. This PR fixes it.

