### PR TITLE
Add Kappal link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Compose Specification is also implemented by:
 * [Okteto Stacks](https://okteto.com/docs/reference/stacks)
 * [Docker Cloud Integrations](https://github.com/docker/compose-cli)
 * [Podman Compose](https://github.com/containers/podman-compose)
+* [Kappal](https://github.com/sandys/kappal)
 
 | Metadata |                  |
 | -------- | ---------------: |


### PR DESCRIPTION
**What this PR does / why we need it**:

Add kappal to the list of implementations. 

Kappal is a cli that runs k3s invisibly using docker compose. Compose UX and the compose file remains the primary way to run and deploy. Under the covers, we transform compose into jsonnet and restructure k3s to execute it.
We pass the Compose conformance tests. 

https://github.com/sandys/kappal


