### PR TITLE
Add `chown` option for bind and volume mounts

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -2089,6 +2089,7 @@ The short syntax uses a single string with colon-separated values to specify a v
   - `ro`: Read-only access.
   - `z`: SELinux option indicating that the bind mount host content is shared among multiple containers.
   - `Z`: SELinux option indicating that the bind mount host content is private and unshared for other containers.
+  - `U`: Recursively chown the source volume using the UID and GID of the container.
 
 > **Note**
 >
@@ -2122,9 +2123,11 @@ expressed in the short form.
   - `propagation`: The propagation mode used for the bind.
   - `create_host_path`: Creates a directory at the source path on the host if it doesn't exist. Defaults to `true`.
   - `selinux`: The SELinux re-labeling option `z` (shared) or `Z` (private)
+  - `chown`: Flag to recursively chown the source using the UID and GID of the container.
 - `volume`: Configures additional volume options:
   - `nocopy`: Flag to disable copying of data from a container when a volume is created.
   - `subpath`: Path inside a volume to mount instead of the volume root.
+  - `chown`: Flag to recursively chown the source volume using the UID and GID of the container.
 - `tmpfs`: Configures additional tmpfs options:
   - `size`: The size for the tmpfs mount in bytes (either numeric or as bytes unit).
   - `mode`: The file mode for the tmpfs mount as Unix permission bits as an octal number. [![Compose v2.14.0](https://img.shields.io/badge/compose-v2.14.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.14.0)

--- a/spec.md
+++ b/spec.md
@@ -2300,6 +2300,7 @@ The short syntax uses a single string with colon-separated values to specify a v
   - `ro`: Read-only access.
   - `z`: SELinux option indicating that the bind mount host content is shared among multiple containers.
   - `Z`: SELinux option indicating that the bind mount host content is private and unshared for other containers.
+  - `U`: Recursively chown the source volume using the UID and GID of the container.
 
 > **Note**
 >
@@ -2333,9 +2334,11 @@ expressed in the short form.
   - `propagation`: The propagation mode used for the bind.
   - `create_host_path`: Creates a directory at the source path on the host if it doesn't exist. Defaults to `true`.
   - `selinux`: The SELinux re-labeling option `z` (shared) or `Z` (private)
+  - `chown`: Flag to recursively chown the source using the UID and GID of the container.
 - `volume`: Configures additional volume options:
   - `nocopy`: Flag to disable copying of data from a container when a volume is created.
   - `subpath`: Path inside a volume to mount instead of the volume root.
+  - `chown`: Flag to recursively chown the source volume using the UID and GID of the container.
 - `tmpfs`: Configures additional tmpfs options:
   - `size`: The size for the tmpfs mount in bytes (either numeric or as bytes unit).
   - `mode`: The file mode for the tmpfs mount as Unix permission bits as an octal number. [![Compose v2.14.0](https://img.shields.io/badge/compose-v2.14.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.14.0)


### PR DESCRIPTION
**What this PR does / why we need it**:

The ability to recursively chown a volume's source is useful when running rootless containers, especially when using automatic user namespace provisioning. Podman supports this with the `U` volume option. See the `--volume` section of the [**podman-run**(1) documentation](https://docs.podman.io/en/v5.7.1/markdown/podman-run.1.html#volume-v-source-volume-host-dir-container-dir-options) for details.

Added the `U` option to the short service volume syntax.

Added the `bind.chown` and `volume.chown` options to the long service volume syntax.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->


