### PR TITLE
Add `max-retries` option to `on-failure` `restart` policy

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -1789,7 +1789,8 @@ services:
 
 - `no`: The default restart policy. It does not restart the container under any circumstances.
 - `always`: The policy always restarts the container until its removal.
-- `on-failure`: The policy restarts the container if the exit code indicates an error.
+- `on-failure[:max-retries]`: The policy restarts the container if the exit code indicates an error.
+  Optionally, limit the number of restart retries the container runtime attempts.
 - `unless-stopped`: The policy restarts the container irrespective of the exit code but stops
   restarting when the service is stopped or removed.
 
@@ -1797,6 +1798,7 @@ services:
     restart: "no"
     restart: always
     restart: on-failure
+    restart: on-failure:3
     restart: unless-stopped
 ```
 

--- a/spec.md
+++ b/spec.md
@@ -2000,7 +2000,8 @@ services:
 
 - `no`: The default restart policy. It does not restart the container under any circumstances.
 - `always`: The policy always restarts the container until its removal.
-- `on-failure`: The policy restarts the container if the exit code indicates an error.
+- `on-failure[:max-retries]`: The policy restarts the container if the exit code indicates an error.
+  Optionally, limit the number of restart retries the container runtime attempts.
 - `unless-stopped`: The policy restarts the container irrespective of the exit code but stops
   restarting when the service is stopped or removed.
 
@@ -2008,6 +2009,7 @@ services:
     restart: "no"
     restart: always
     restart: on-failure
+    restart: on-failure:3
     restart: unless-stopped
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Matches the option defined in the [Docker docs](https://github.com/docker/docs/blob/7e2af24707f4cbc0e04a58ae5481348e0296661f/content/reference/compose-file/services.md#restart).

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->


