### PR TITLE
Clarify mem_swappiness percentage range and effects

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -1228,11 +1228,12 @@ When both are set, `mem_reservation` must be consistent with the `reservations.m
 
 ## mem_swappiness
 
-`mem_swappiness` defines as a percentage, a value between 0 and 100, for the host kernel to swap out
-anonymous memory pages used by a container.
+`mem_swappiness` defines as a percentage, a value between 0 and 200, for the host kernel to estimate swapping cost.
+See: [Kernel Docs](https://www.kernel.org/doc/html/latest/admin-guide/sysctl/vm.html#swappiness) for details.
 
-- `0`: Turns off anonymous page swapping.
-- `100`: Sets all anonymous pages as swappable.
+- `0`: Avoid anonymous page swapping.
+- `100`: Sets all anonymous pages to be equaly expensive to swap as file backed pages.
+- `200`: Prefer swapping of anonymous page over file backed pages.
 
 The default value is platform specific.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Is the `mem_swappiness` parameter the same as the host parameter `/proc/sys/vm/swappiness` ? if so the current documentation is misleading. I tried to come up with a better text.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #


