### PR TITLE
add missing version badges on recently introduced attributes

### DIFF
--- a/05-services.md
+++ b/05-services.md
@@ -22,6 +22,8 @@ If not implemented the `deploy` section is ignored and the Compose file is still
 
 ## annotations
 
+[![Compose v2.18.0](https://img.shields.io/badge/compose-v2.18.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.18.0)
+
 `annotations` defines annotations for the container. `annotations` can use either an array or a map.
 
 ```yml
@@ -598,6 +600,8 @@ attributes
 
 ### required
 
+[![Compose v2.24.0](https://img.shields.io/badge/compose-v2.24.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.24.0)
+
 `required` attribute defaults to `true`. When `required` is set to `false` and the `.env` file is missing,
 Compose silently ignores the entry.
 
@@ -610,6 +614,8 @@ env_file:
 ```
 
 ### format
+
+[![Compose v2.30.0](https://img.shields.io/badge/compose-v2.30.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.30.0)
 
 `format` attribute lets you to use an alternative file formats for `env_file`. When not set, `env_file` is parsed according to 
 Compose rules as described in next section.
@@ -1463,6 +1469,8 @@ networks:
 
 ### mac_address
 
+[![Compose v2.24.0](https://img.shields.io/badge/compose-v2.24.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.24.0)
+
 `mac_address` sets the MAC address used by the service container when connecting to this particular network.
 
 ### driver_opts
@@ -1667,6 +1675,8 @@ ports:
 
 ## post_start
 
+[![Compose v2.30.0](https://img.shields.io/badge/compose-v2.30.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.30.0)
+
 `post_start` defines a sequence of lifecycle hooks to run after a container has started. The exact timing of when the command is run is not guaranteed.
 
 - `command`: The command to run after the container has started. This attribute is required.
@@ -1688,6 +1698,8 @@ services:
 ```
 
 ## pre_start
+
+[![Compose v5.3.0](https://img.shields.io/badge/compose-v5.3.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v5.3.0)
 
 `pre_start` defines a sequence of init containers to run before the service container is started. Each step runs to completion, in declared order, and the service container only starts once every step has exited 0. A non-zero exit fails the bring-up of the service and its dependents.
 
@@ -1731,6 +1743,8 @@ volumes:
 ```
 
 ## pre_stop
+
+[![Compose v2.30.0](https://img.shields.io/badge/compose-v2.30.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.30.0)
 
 `pre_stop` defines a sequence of lifecycle hooks to run before service termination.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Compose Specification — agent instructions
+
+This repository is the Compose Specification: the normative markdown
+chapters (`0*-*.md`, `build.md`, `deploy.md`, `develop.md`, `models.md`) plus
+`spec.md`, which is **generated** from them — never edit `spec.md` directly,
+regenerate it with `make spec` after changing any chapter.
+
+## Version badge rule
+
+Every attribute documented in the spec carries a badge stating the Docker
+Compose release that introduced it, placed on its own line right after the
+attribute heading:
+
+```markdown
+## some_attribute
+
+[![Compose v2.30.0](https://img.shields.io/badge/compose-v2.30.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.30.0)
+```
+
+**When documenting a new attribute, always add this badge.** The release
+that will ship the attribute is usually unknown at the time the spec change
+is written: use the `NEXT` placeholder, to be replaced with the actual
+version once the next Docker Compose release is cut:
+
+```markdown
+[![Compose NEXT](https://img.shields.io/badge/compose-NEXT-blue?style=flat-square)](https://github.com/docker/compose/releases)
+```
+
+`NEXT` is greppable on purpose: at release time, maintainers sweep the repo
+for `compose-NEXT` and pin the badges to the released version (including the
+release link). Only the long-standing attributes inherited from the original
+2021 schema import go without a badge — anything added since then must have
+one.
+
+## Checks before submitting
+
+- `make spec` — regenerate `spec.md` (CI fails if it drifts).
+- Every commit needs a DCO `Signed-off-by` trailer (`git commit -s`).

--- a/develop.md
+++ b/develop.md
@@ -44,6 +44,8 @@ The `develop` subsection defines configuration options that are applied by Compo
 
 ### watch
 
+[![Compose v2.22.0](https://img.shields.io/badge/compose-v2.22.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.22.0)
+
 The `watch` attribute defines a list of rules that control automatic service updates based on local file changes. `watch` is a sequence, each individual item in the sequence defines a rule to be applied by 
 Compose to monitor source code for changes. For more information, see [Use Compose Watch](https://docs.docker.com/compose/file-watch/).
 
@@ -59,6 +61,8 @@ Compose to monitor source code for changes. For more information, see [Use Compo
 
 
 #### exec
+
+[![Compose v2.32.0](https://img.shields.io/badge/compose-v2.32.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.32.0)
 
 `exec` is only relevant when `action` is set to `sync+exec`. Comparable to [service hooks](05-services.md#post_start), `exec` is used to defined command to be ran inside container:
 
@@ -98,6 +102,8 @@ for the `ignores` file, and values set in the Compose model are appended.
 
 #### include
 
+[![Compose v2.34.0](https://img.shields.io/badge/compose-v2.34.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.34.0)
+
 It is sometimes easier to select files to be watched _vs_ declaring those **not** to be watched by `ignore`.
 The `include` attribute can be used to define a pattern or a list of patterns for paths to be considered for watching.
 Only files that matches these patterns will be considered when applying a watch rule. The syntax is the same as `ignore`.
@@ -120,6 +126,8 @@ services:
 > to define an [alias node](https://yaml.org/spec/1.2.2/#alias-nodes) so you'll have to wrap pattern expression with quotes.
 
 #### initial_sync
+
+[![Compose v2.39.4](https://img.shields.io/badge/compose-v2.39.4-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.39.4)
 
 When using `sync+x` actions, it can be useful to ensure that files inside containers are up to date at the start of a new watch session.
 

--- a/spec.md
+++ b/spec.md
@@ -233,6 +233,8 @@ If not implemented the `deploy` section is ignored and the Compose file is still
 
 ## annotations
 
+[![Compose v2.18.0](https://img.shields.io/badge/compose-v2.18.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.18.0)
+
 `annotations` defines annotations for the container. `annotations` can use either an array or a map.
 
 ```yml
@@ -809,6 +811,8 @@ attributes
 
 ### required
 
+[![Compose v2.24.0](https://img.shields.io/badge/compose-v2.24.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.24.0)
+
 `required` attribute defaults to `true`. When `required` is set to `false` and the `.env` file is missing,
 Compose silently ignores the entry.
 
@@ -821,6 +825,8 @@ env_file:
 ```
 
 ### format
+
+[![Compose v2.30.0](https://img.shields.io/badge/compose-v2.30.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.30.0)
 
 `format` attribute lets you to use an alternative file formats for `env_file`. When not set, `env_file` is parsed according to 
 Compose rules as described in next section.
@@ -1674,6 +1680,8 @@ networks:
 
 ### mac_address
 
+[![Compose v2.24.0](https://img.shields.io/badge/compose-v2.24.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.24.0)
+
 `mac_address` sets the MAC address used by the service container when connecting to this particular network.
 
 ### driver_opts
@@ -1878,6 +1886,8 @@ ports:
 
 ## post_start
 
+[![Compose v2.30.0](https://img.shields.io/badge/compose-v2.30.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.30.0)
+
 `post_start` defines a sequence of lifecycle hooks to run after a container has started. The exact timing of when the command is run is not guaranteed.
 
 - `command`: The command to run after the container has started. This attribute is required.
@@ -1899,6 +1909,8 @@ services:
 ```
 
 ## pre_start
+
+[![Compose v5.3.0](https://img.shields.io/badge/compose-v5.3.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v5.3.0)
 
 `pre_start` defines a sequence of init containers to run before the service container is started. Each step runs to completion, in declared order, and the service container only starts once every step has exited 0. A non-zero exit fails the bring-up of the service and its dependents.
 
@@ -1942,6 +1954,8 @@ volumes:
 ```
 
 ## pre_stop
+
+[![Compose v2.30.0](https://img.shields.io/badge/compose-v2.30.0-blue?style=flat-square)](https://github.com/docker/compose/releases/v2.30.0)
 
 `pre_stop` defines a sequence of lifecycle hooks to run before service termination.
 


### PR DESCRIPTION
Several recently introduced attributes are documented without the version badge stating the Docker Compose release that introduced them (`pre_start` for example). This adds the missing badges; each introduction was identified in compose-go's schema history and mapped to the first docker/compose release embedding that compose-go commit:

| attribute | first release |
|---|---|
| `annotations` | v2.18.0 |
| `env_file.required` | v2.24.0 |
| `env_file.format` | v2.30.0 |
| service `networks.mac_address` | v2.24.0 |
| `post_start`, `pre_stop` | v2.30.0 |
| `pre_start` | v5.3.0 |
| `develop.watch` | v2.22.0 |
| `watch.exec` | v2.32.0 |
| `watch.include` | v2.34.0 |
| `watch.initial_sync` | v2.39.4 |

`spec.md` regenerated with `make spec`.

A second commit adds `AGENTS.md` codifying the rule going forward: documenting a new attribute requires its version badge, defaulting to a greppable `NEXT` placeholder pinned to the actual version when the next release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)